### PR TITLE
Fix downsampling translation

### DIFF
--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -29,7 +29,7 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-b19461e"
+IMAGE_VERSION = "dev-538e521"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
 JOB_TYPE = "default"  # registered job type on the dev cluster
@@ -66,7 +66,7 @@ def _estimate_resources(
     # num_partitions = min(n_tiles, MAX_PARTITIONS)
     # tiles_per_partition = max(n_tiles // num_partitions, 1)
     # we want to run multiple partitions per file
-    num_partitions = 8
+    num_partitions = 32
 
     # estimated_mem = (
     #     tiles_per_partition * SCHEDULING_OVERHEAD_MB

--- a/src/aind_exaspim_data_transformation/__init__.py
+++ b/src/aind_exaspim_data_transformation/__init__.py
@@ -1,6 +1,6 @@
 """Init package"""
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 __authors__ = ["Carson Berry"]
 __author_emails__ = [
     "carson.berry@alleninstitute.org",

--- a/src/aind_exaspim_data_transformation/compress/imaris_to_zarr.py
+++ b/src/aind_exaspim_data_transformation/compress/imaris_to_zarr.py
@@ -904,6 +904,10 @@ def imaris_to_zarr_writer(
         else:
             logger.info(f"Using provided voxel size: {voxel_size}")
 
+        # Get origin for proper coordinate transformations
+        origin = reader.get_origin()
+        logger.info(f"Extracted origin from Imaris: {origin}")
+
         # Determine actual number of levels available
         available_levels = reader.n_levels
         actual_n_lvls = min(n_lvls, available_levels)
@@ -975,6 +979,7 @@ def imaris_to_zarr_writer(
             scale_factors=tuple(scale_factor),
             voxel_size=tuple(voxel_size),
             channel_names=[channel_name or stack_name],
+            origin=origin,
         )
 
         root.attrs.update(metadata_dict)
@@ -1339,6 +1344,10 @@ def imaris_to_zarr_parallel(
         else:
             logger.info(f"Using provided voxel size: {voxel_size}")
 
+        # Get origin for proper coordinate transformations
+        origin = reader.get_origin()
+        logger.info(f"Extracted origin from Imaris: {origin}")
+
         # Get shape and dtype from base resolution
         base_path = _data_path(0)
         shape_3d = cast(
@@ -1474,6 +1483,7 @@ def imaris_to_zarr_parallel(
         scale_factors=scale_factor,
         voxel_size=tuple(voxel_size),
         channel_names=[channel_name or stack_name],
+        origin=origin,
     )
 
     # Write metadata to zarr.json
@@ -1680,6 +1690,10 @@ def imaris_to_zarr_distributed(
         if voxel_size is None:
             voxel_size, unit = reader.get_voxel_size()
             logger.info(f"Extracted voxel size: {voxel_size} {unit}")
+
+        # Get origin for proper coordinate transformations
+        origin = reader.get_origin()
+        logger.info(f"Extracted origin from Imaris: {origin}")
 
         logger.debug("Using voxel_size=%s", voxel_size)
 
@@ -1994,6 +2008,7 @@ def imaris_to_zarr_distributed(
             scale_factors=scale_factor,
             voxel_size=tuple(voxel_size),
             channel_names=[channel_name or stack_name],
+            origin=origin,
         )
 
         _write_zarr_metadata(store_path, metadata_dict, is_s3)
@@ -2169,6 +2184,10 @@ def imaris_to_zarr_translate_pyramid(
         else:
             logger.info(f"Using provided voxel size: {voxel_size}")
 
+        # Get origin for proper coordinate transformations
+        origin = reader.get_origin()
+        logger.info(f"Extracted origin from Imaris: {origin}")
+
         # Count available pyramid levels in Imaris file
         available_levels = _count_imaris_levels(reader)
         logger.info(
@@ -2326,6 +2345,7 @@ def imaris_to_zarr_translate_pyramid(
         scale_factors=representative_factor,
         voxel_size=tuple(voxel_size),
         channel_names=[channel_name or stack_name],
+        origin=origin,
     )
 
     # Write metadata to zarr.json

--- a/src/aind_exaspim_data_transformation/models.py
+++ b/src/aind_exaspim_data_transformation/models.py
@@ -62,7 +62,7 @@ class ImarisJobSettings(BasicJobSettings):
         title="Shard Size",
     )
     chunk_size: List[int] = Field(
-        default=[128, 128, 128],  # Default list with three integers
+        default=[128, 256, 256],  # Default list with three integers
         description="Chunk size in axis, a list of three integers",
         title="Chunk Size",
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,7 +55,7 @@ class TestImarisJobSettings(unittest.TestCase):
             partition_to_process=0,
         )
 
-        self.assertEqual(settings.chunk_size, [128, 128, 128])
+        self.assertEqual(settings.chunk_size, [128, 256, 256])
 
     def test_default_scale_factor(self):
         """Test default scale factor"""

--- a/tests/test_translation_fix.py
+++ b/tests/test_translation_fix.py
@@ -47,7 +47,7 @@ class TestTranslationFields(unittest.TestCase):
         for i, dataset in enumerate(datasets):
             with self.subTest(level=i):
                 transforms = dataset.get("coordinateTransformations", [])
-                
+
                 # Find translation transform
                 translation_transform = None
                 for transform in transforms:
@@ -58,7 +58,7 @@ class TestTranslationFields(unittest.TestCase):
                 # Assert translation exists
                 self.assertIsNotNone(
                     translation_transform,
-                    f"Level {i} is missing translation field"
+                    f"Level {i} is missing translation field",
                 )
 
                 # Verify translation is a list of 5 floats
@@ -86,17 +86,19 @@ class TestTranslationFields(unittest.TestCase):
 
         # Expected translations for 2x downsampling with scale_factors=(1, 2, 2)
         expected_translations = [
-            [0.0, 0.0, 0.0, 0.0, 0.0],    # Level 0 (1x)
-            [0.0, 0.0, 0.0, 0.5, 0.5],    # Level 1 (2x)
-            [0.0, 0.0, 0.0, 1.5, 1.5],    # Level 2 (4x)
-            [0.0, 0.0, 0.0, 3.5, 3.5],    # Level 3 (8x)
-            [0.0, 0.0, 0.0, 7.5, 7.5],    # Level 4 (16x)
+            [0.0, 0.0, 0.0, 0.0, 0.0],  # Level 0 (1x)
+            [0.0, 0.0, 0.0, 0.5, 0.5],  # Level 1 (2x)
+            [0.0, 0.0, 0.0, 1.5, 1.5],  # Level 2 (4x)
+            [0.0, 0.0, 0.0, 3.5, 3.5],  # Level 3 (8x)
+            [0.0, 0.0, 0.0, 7.5, 7.5],  # Level 4 (16x)
         ]
 
-        for i, (dataset, expected) in enumerate(zip(datasets, expected_translations)):
+        for i, (dataset, expected) in enumerate(
+            zip(datasets, expected_translations)
+        ):
             with self.subTest(level=i):
                 transforms = dataset.get("coordinateTransformations", [])
-                
+
                 # Find translation transform
                 translation = None
                 for transform in transforms:
@@ -106,9 +108,7 @@ class TestTranslationFields(unittest.TestCase):
 
                 self.assertIsNotNone(translation)
                 self.assertEqual(
-                    translation,
-                    expected,
-                    f"Level {i} translation mismatch"
+                    translation, expected, f"Level {i} translation mismatch"
                 )
 
     def test_scale_and_translation_both_present(self):
@@ -130,14 +130,20 @@ class TestTranslationFields(unittest.TestCase):
         for i, dataset in enumerate(datasets):
             with self.subTest(level=i):
                 transforms = dataset.get("coordinateTransformations", [])
-                
+
                 # Check for scale transform
                 has_scale = any(t.get("type") == "scale" for t in transforms)
-                self.assertTrue(has_scale, f"Level {i} missing scale transform")
-                
+                self.assertTrue(
+                    has_scale, f"Level {i} missing scale transform"
+                )
+
                 # Check for translation transform
-                has_translation = any(t.get("type") == "translation" for t in transforms)
-                self.assertTrue(has_translation, f"Level {i} missing translation transform")
+                has_translation = any(
+                    t.get("type") == "translation" for t in transforms
+                )
+                self.assertTrue(
+                    has_translation, f"Level {i} missing translation transform"
+                )
 
     def test_without_origin_parameter(self):
         """Test that metadata can be generated without origin (backwards compatibility)."""

--- a/tests/test_translation_fix.py
+++ b/tests/test_translation_fix.py
@@ -1,0 +1,86 @@
+"""
+Test script to verify that translation fields are now included in zarr.json
+"""
+import json
+from aind_exaspim_data_transformation.compress.omezarr_metadata import (
+    write_ome_ngff_metadata,
+)
+
+# Test parameters similar to what the conversion functions use
+arr_shape = [1, 1, 768, 2688, 3584]
+chunk_size = [1, 1, 128, 128, 128]
+image_name = "test_image"
+n_lvls = 5
+scale_factors = (1.0, 2.0, 2.0)  # Z, Y, X
+voxel_size = (1.0, 1.0, 1.0)  # Z, Y, X in micrometers
+channel_names = ["test_channel"]
+origin = [0.0, 0.0, 0.0]  # Z, Y, X origin
+
+print("Testing metadata generation WITH origin parameter...")
+metadata_with_origin = write_ome_ngff_metadata(
+    arr_shape=arr_shape,
+    chunk_size=chunk_size,
+    image_name=image_name,
+    n_lvls=n_lvls,
+    scale_factors=scale_factors,
+    voxel_size=voxel_size,
+    channel_names=channel_names,
+    origin=origin,
+)
+
+print("\nGenerated metadata:")
+print(json.dumps(metadata_with_origin, indent=2))
+
+# Check if translations are present
+multiscales = metadata_with_origin["attributes"]["ome"]["multiscales"][0]
+datasets = multiscales["datasets"]
+
+print("\n" + "="*80)
+print("Checking translation fields in each pyramid level:")
+print("="*80)
+
+all_have_translations = True
+for i, dataset in enumerate(datasets):
+    transforms = dataset.get("coordinateTransformations", [])
+    has_translation = False
+    translation_value = None
+    
+    for transform in transforms:
+        if transform.get("type") == "translation":
+            has_translation = True
+            translation_value = transform.get("translation")
+            break
+    
+    if has_translation:
+        print(f"✓ Level {i}: HAS translation field: {translation_value}")
+    else:
+        print(f"✗ Level {i}: MISSING translation field")
+        all_have_translations = False
+
+print("\n" + "="*80)
+if all_have_translations:
+    print("SUCCESS: All pyramid levels have translation fields!")
+else:
+    print("FAILURE: Some pyramid levels are missing translation fields")
+print("="*80)
+
+# Verify the translation values follow the expected pattern
+print("\nVerifying translation values follow expected pattern:")
+print("Expected pattern for 2x downsampling:")
+print("  Level 0 (scale 1x):  translation = [0.0, 0.0, 0.0, 0.0, 0.0]")
+print("  Level 1 (scale 2x):  translation = [0.0, 0.0, 0.5, 0.5, 0.5]")
+print("  Level 2 (scale 4x):  translation = [0.0, 0.0, 1.5, 1.5, 1.5]")
+print("  Level 3 (scale 8x):  translation = [0.0, 0.0, 3.5, 3.5, 3.5]")
+print("  Level 4 (scale 16x): translation = [0.0, 0.0, 7.5, 7.5, 7.5]")
+
+print("\nActual translations:")
+for i, dataset in enumerate(datasets):
+    transforms = dataset.get("coordinateTransformations", [])
+    for transform in transforms:
+        if transform.get("type") == "translation":
+            translation = transform.get("translation")
+            print(f"  Level {i}: translation = {translation}")
+
+print("\n" + "="*80)
+print("Test completed!")
+print("="*80)

--- a/tests/test_translation_fix.py
+++ b/tests/test_translation_fix.py
@@ -1,7 +1,9 @@
 """
 Test script to verify that translation fields are now included in zarr.json
 """
+
 import json
+
 from aind_exaspim_data_transformation.compress.omezarr_metadata import (
     write_ome_ngff_metadata,
 )
@@ -35,34 +37,34 @@ print(json.dumps(metadata_with_origin, indent=2))
 multiscales = metadata_with_origin["attributes"]["ome"]["multiscales"][0]
 datasets = multiscales["datasets"]
 
-print("\n" + "="*80)
+print("\n" + "=" * 80)
 print("Checking translation fields in each pyramid level:")
-print("="*80)
+print("=" * 80)
 
 all_have_translations = True
 for i, dataset in enumerate(datasets):
     transforms = dataset.get("coordinateTransformations", [])
     has_translation = False
     translation_value = None
-    
+
     for transform in transforms:
         if transform.get("type") == "translation":
             has_translation = True
             translation_value = transform.get("translation")
             break
-    
+
     if has_translation:
         print(f"✓ Level {i}: HAS translation field: {translation_value}")
     else:
         print(f"✗ Level {i}: MISSING translation field")
         all_have_translations = False
 
-print("\n" + "="*80)
+print("\n" + "=" * 80)
 if all_have_translations:
     print("SUCCESS: All pyramid levels have translation fields!")
 else:
     print("FAILURE: Some pyramid levels are missing translation fields")
-print("="*80)
+print("=" * 80)
 
 # Verify the translation values follow the expected pattern
 print("\nVerifying translation values follow expected pattern:")
@@ -81,6 +83,6 @@ for i, dataset in enumerate(datasets):
             translation = transform.get("translation")
             print(f"  Level {i}: translation = {translation}")
 
-print("\n" + "="*80)
+print("\n" + "=" * 80)
 print("Test completed!")
-print("="*80)
+print("=" * 80)

--- a/tests/test_translation_fix.py
+++ b/tests/test_translation_fix.py
@@ -1,88 +1,165 @@
 """
-Test script to verify that translation fields are now included in zarr.json
+Tests to verify that translation fields are included in zarr.json metadata
+for downsampled pyramid levels.
 """
 
-import json
+import unittest
 
 from aind_exaspim_data_transformation.compress.omezarr_metadata import (
     write_ome_ngff_metadata,
 )
 
-# Test parameters similar to what the conversion functions use
-arr_shape = [1, 1, 768, 2688, 3584]
-chunk_size = [1, 1, 128, 128, 128]
-image_name = "test_image"
-n_lvls = 5
-scale_factors = (1.0, 2.0, 2.0)  # Z, Y, X
-voxel_size = (1.0, 1.0, 1.0)  # Z, Y, X in micrometers
-channel_names = ["test_channel"]
-origin = [0.0, 0.0, 0.0]  # Z, Y, X origin
 
-print("Testing metadata generation WITH origin parameter...")
-metadata_with_origin = write_ome_ngff_metadata(
-    arr_shape=arr_shape,
-    chunk_size=chunk_size,
-    image_name=image_name,
-    n_lvls=n_lvls,
-    scale_factors=scale_factors,
-    voxel_size=voxel_size,
-    channel_names=channel_names,
-    origin=origin,
-)
+class TestTranslationFields(unittest.TestCase):
+    """Test that translation coordinate transformations are properly generated."""
 
-print("\nGenerated metadata:")
-print(json.dumps(metadata_with_origin, indent=2))
+    def setUp(self):
+        """Set up test parameters."""
+        self.arr_shape = [1, 1, 768, 2688, 3584]
+        self.chunk_size = [1, 1, 128, 128, 128]
+        self.image_name = "test_image"
+        self.n_lvls = 5
+        self.scale_factors = (1.0, 2.0, 2.0)  # Z, Y, X
+        self.voxel_size = (1.0, 1.0, 1.0)  # Z, Y, X in micrometers
+        self.channel_names = ["test_channel"]
+        self.origin = [0.0, 0.0, 0.0]  # Z, Y, X origin
 
-# Check if translations are present
-multiscales = metadata_with_origin["attributes"]["ome"]["multiscales"][0]
-datasets = multiscales["datasets"]
+    def test_translation_fields_present_with_origin(self):
+        """Test that all pyramid levels have translation fields when origin is provided."""
+        metadata = write_ome_ngff_metadata(
+            arr_shape=self.arr_shape,
+            chunk_size=self.chunk_size,
+            image_name=self.image_name,
+            n_lvls=self.n_lvls,
+            scale_factors=self.scale_factors,
+            voxel_size=self.voxel_size,
+            channel_names=self.channel_names,
+            origin=self.origin,
+        )
 
-print("\n" + "=" * 80)
-print("Checking translation fields in each pyramid level:")
-print("=" * 80)
+        multiscales = metadata["attributes"]["ome"]["multiscales"][0]
+        datasets = multiscales["datasets"]
 
-all_have_translations = True
-for i, dataset in enumerate(datasets):
-    transforms = dataset.get("coordinateTransformations", [])
-    has_translation = False
-    translation_value = None
+        # Check that we have the expected number of levels
+        self.assertEqual(len(datasets), self.n_lvls)
 
-    for transform in transforms:
-        if transform.get("type") == "translation":
-            has_translation = True
-            translation_value = transform.get("translation")
-            break
+        # Verify each level has a translation field
+        for i, dataset in enumerate(datasets):
+            with self.subTest(level=i):
+                transforms = dataset.get("coordinateTransformations", [])
+                
+                # Find translation transform
+                translation_transform = None
+                for transform in transforms:
+                    if transform.get("type") == "translation":
+                        translation_transform = transform
+                        break
 
-    if has_translation:
-        print(f"✓ Level {i}: HAS translation field: {translation_value}")
-    else:
-        print(f"✗ Level {i}: MISSING translation field")
-        all_have_translations = False
+                # Assert translation exists
+                self.assertIsNotNone(
+                    translation_transform,
+                    f"Level {i} is missing translation field"
+                )
 
-print("\n" + "=" * 80)
-if all_have_translations:
-    print("SUCCESS: All pyramid levels have translation fields!")
-else:
-    print("FAILURE: Some pyramid levels are missing translation fields")
-print("=" * 80)
+                # Verify translation is a list of 5 floats
+                translation = translation_transform.get("translation")
+                self.assertIsInstance(translation, list)
+                self.assertEqual(len(translation), 5)
+                for val in translation:
+                    self.assertIsInstance(val, (int, float))
 
-# Verify the translation values follow the expected pattern
-print("\nVerifying translation values follow expected pattern:")
-print("Expected pattern for 2x downsampling:")
-print("  Level 0 (scale 1x):  translation = [0.0, 0.0, 0.0, 0.0, 0.0]")
-print("  Level 1 (scale 2x):  translation = [0.0, 0.0, 0.5, 0.5, 0.5]")
-print("  Level 2 (scale 4x):  translation = [0.0, 0.0, 1.5, 1.5, 1.5]")
-print("  Level 3 (scale 8x):  translation = [0.0, 0.0, 3.5, 3.5, 3.5]")
-print("  Level 4 (scale 16x): translation = [0.0, 0.0, 7.5, 7.5, 7.5]")
+    def test_translation_values_follow_expected_pattern(self):
+        """Test that translation values follow the expected downsampling pattern."""
+        metadata = write_ome_ngff_metadata(
+            arr_shape=self.arr_shape,
+            chunk_size=self.chunk_size,
+            image_name=self.image_name,
+            n_lvls=self.n_lvls,
+            scale_factors=self.scale_factors,
+            voxel_size=self.voxel_size,
+            channel_names=self.channel_names,
+            origin=self.origin,
+        )
 
-print("\nActual translations:")
-for i, dataset in enumerate(datasets):
-    transforms = dataset.get("coordinateTransformations", [])
-    for transform in transforms:
-        if transform.get("type") == "translation":
-            translation = transform.get("translation")
-            print(f"  Level {i}: translation = {translation}")
+        multiscales = metadata["attributes"]["ome"]["multiscales"][0]
+        datasets = multiscales["datasets"]
 
-print("\n" + "=" * 80)
-print("Test completed!")
-print("=" * 80)
+        # Expected translations for 2x downsampling with scale_factors=(1, 2, 2)
+        expected_translations = [
+            [0.0, 0.0, 0.0, 0.0, 0.0],    # Level 0 (1x)
+            [0.0, 0.0, 0.0, 0.5, 0.5],    # Level 1 (2x)
+            [0.0, 0.0, 0.0, 1.5, 1.5],    # Level 2 (4x)
+            [0.0, 0.0, 0.0, 3.5, 3.5],    # Level 3 (8x)
+            [0.0, 0.0, 0.0, 7.5, 7.5],    # Level 4 (16x)
+        ]
+
+        for i, (dataset, expected) in enumerate(zip(datasets, expected_translations)):
+            with self.subTest(level=i):
+                transforms = dataset.get("coordinateTransformations", [])
+                
+                # Find translation transform
+                translation = None
+                for transform in transforms:
+                    if transform.get("type") == "translation":
+                        translation = transform.get("translation")
+                        break
+
+                self.assertIsNotNone(translation)
+                self.assertEqual(
+                    translation,
+                    expected,
+                    f"Level {i} translation mismatch"
+                )
+
+    def test_scale_and_translation_both_present(self):
+        """Test that both scale and translation transforms are present for each level."""
+        metadata = write_ome_ngff_metadata(
+            arr_shape=self.arr_shape,
+            chunk_size=self.chunk_size,
+            image_name=self.image_name,
+            n_lvls=self.n_lvls,
+            scale_factors=self.scale_factors,
+            voxel_size=self.voxel_size,
+            channel_names=self.channel_names,
+            origin=self.origin,
+        )
+
+        multiscales = metadata["attributes"]["ome"]["multiscales"][0]
+        datasets = multiscales["datasets"]
+
+        for i, dataset in enumerate(datasets):
+            with self.subTest(level=i):
+                transforms = dataset.get("coordinateTransformations", [])
+                
+                # Check for scale transform
+                has_scale = any(t.get("type") == "scale" for t in transforms)
+                self.assertTrue(has_scale, f"Level {i} missing scale transform")
+                
+                # Check for translation transform
+                has_translation = any(t.get("type") == "translation" for t in transforms)
+                self.assertTrue(has_translation, f"Level {i} missing translation transform")
+
+    def test_without_origin_parameter(self):
+        """Test that metadata can be generated without origin (backwards compatibility)."""
+        # This should not raise an error, but translations won't be included
+        metadata = write_ome_ngff_metadata(
+            arr_shape=self.arr_shape,
+            chunk_size=self.chunk_size,
+            image_name=self.image_name,
+            n_lvls=self.n_lvls,
+            scale_factors=self.scale_factors,
+            voxel_size=self.voxel_size,
+            channel_names=self.channel_names,
+            # origin parameter omitted
+        )
+
+        # Should still generate valid metadata
+        self.assertIn("attributes", metadata)
+        self.assertIn("ome", metadata["attributes"])
+        multiscales = metadata["attributes"]["ome"]["multiscales"][0]
+        datasets = multiscales["datasets"]
+        self.assertEqual(len(datasets), self.n_lvls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ensure translation fields are written in zarrv3 zarr.json files. This should align volume edges better in permissible viewing environments like Neuroglancer. 