### PR TITLE
Release v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,38 @@ Alternatively, if using `uv`, run
 ```bash
 uv sync
 ```
+
+## Features
+
+### Single Tile Upload Mode
+
+For integration testing and performance validation of very large datasets, the package supports a `single_tile_upload` mode. When enabled, only the first tile/file from the dataset is processed, while still maintaining full horizontal scaling across workers.
+
+**Use Case**: Testing upload performance on representative data (e.g., 6TB tile) without processing the entire dataset (e.g., 120TB).
+
+**Configuration**:
+```json
+{
+    "input_source": "s3://bucket/dataset",
+    "output_directory": "/scratch/output",
+    "s3_location": "s3://bucket/zarr-output",
+    "num_of_partitions": 16,
+    "partition_to_process": 0,
+    "partition_mode": "shard",
+    "single_tile_upload": true
+}
+```
+
+**Key Points**:
+- The first tile is selected after deterministic sorting (all workers select the same file)
+- The selected tile is still distributed across workers using the configured partitioning strategy
+- Works with both `shard` and `file` partition modes
+- Default value is `false` for backward compatibility
+
+**Benefits**:
+- ~95% cost reduction for integration tests
+- Faster iteration cycles for debugging and optimization
+- Realistic performance testing with representative data volume
+- Same code paths as production (just with restricted input scope)
+
+For more details, see [Single Tile Upload Design Document](docs/SINGLE_TILE_UPLOAD_DESIGN.md).

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -120,6 +120,7 @@ def submit_exaspim_job(
     source: str,
     project_name: str = "MSMA Platform",
     subject_id: str | None = None,
+    single_tile_upload: bool = False,
 ) -> None:
     """Build and POST an ExaSPIM transformation job.
 
@@ -131,6 +132,9 @@ def submit_exaspim_job(
         Project name for the upload job.
     subject_id : str | None
         Subject ID. Derived from *source* folder name when ``None``.
+    single_tile_upload : bool
+        If True, only process the first tile for integration testing.
+        Default is False (process all tiles).
     """
     if subject_id is None:
         subject_id = _derive_subject_id(source)
@@ -148,6 +152,8 @@ def submit_exaspim_job(
     print(f"Partitions        : {num_partitions}")
     print(f"Memory / CPU      : {mem_mb:,} MB")
     print(f"Timeout           : {timeout_min} min")
+    if single_tile_upload:
+        print(f"Single tile mode  : ENABLED (testing first tile only)")
 
     exaspim_job_settings = {
         "input_source": source,
@@ -158,6 +164,7 @@ def submit_exaspim_job(
         "translate_imaris_pyramid": True,
         "partition_mode": "shard",
         "dask_workers": CPUS_PER_NODE,  # use all CPUs for distributed processing
+        "single_tile_upload": single_tile_upload,
     }
 
     custom_exaspim_task = Task(
@@ -238,6 +245,7 @@ def test_submit_exaspim_job():
         source=data_dir,
         project_name="MSMA Platform",
         subject_id="683791-screen",
+        single_tile_upload=True,  # Set to True for testing with a single tile
     )
 
 
@@ -266,12 +274,18 @@ def main():
         default=None,
         help="Subject ID. Derived from folder name if omitted.",
     )
+    parser.add_argument(
+        "--single-tile",
+        action="store_true",
+        help="Process only the first tile (for integration testing).",
+    )
     args = parser.parse_args()
 
     submit_exaspim_job(
         source=args.input_folder,
         project_name=args.project_name,
         subject_id=args.subject_id,
+        single_tile_upload=args.single_tile,
     )
 
 

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -29,7 +29,7 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-caf06f6"
+IMAGE_VERSION = "dev-2bd972f"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
 JOB_TYPE = "default"  # registered job type on the dev cluster
@@ -246,7 +246,7 @@ def test_submit_exaspim_job():
         source=data_dir,
         project_name="MSMA Platform",
         subject_id="785688",
-        single_tile_upload=False,  # Set to True for testing with a single tile
+        single_tile_upload=True,  # Set to True for testing with a single tile
     )
 
 

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -29,16 +29,16 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-18eaef6"
+IMAGE_VERSION = "dev-caf06f6"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
 JOB_TYPE = "default"  # registered job type on the dev cluster
 
 # Resource limits
-MAX_PARTITIONS = 32
+MAX_PARTITIONS = 64
 CPUS_PER_NODE = 4
 MIN_RAM_MB = 24_000
-MAX_RAM_MB = 40_000
+MAX_RAM_MB = 50_000
 SCHEDULING_OVERHEAD_MB = 1_300  # per tile, from profiling
 PROCESSING_OVERHEAD_MB = 4_400  # per shard, from profiling
 BUFFER_MB = 1_000
@@ -66,7 +66,7 @@ def _estimate_resources(
     # num_partitions = min(n_tiles, MAX_PARTITIONS)
     # tiles_per_partition = max(n_tiles // num_partitions, 1)
     # we want to run multiple partitions per file
-    num_partitions = 32
+    num_partitions = MAX_PARTITIONS
 
     # estimated_mem = (
     #     tiles_per_partition * SCHEDULING_OVERHEAD_MB
@@ -82,9 +82,7 @@ def _estimate_resources(
         MAX_RAM_MB // CPUS_PER_NODE,
     )
 
-    timeout_min = int(
-        (n_tiles * tile_size_mb / 1024) / PROCESSING_SPEED_MB_PER_HOUR + 60
-    )
+    timeout_min = int(24 * 60)
 
     return num_partitions, memory_per_cpu, timeout_min
 
@@ -220,6 +218,7 @@ def submit_exaspim_job(
             "register_data_asset": {"skip_task": True},
             "get_codeocean_asset_id": {"skip_task": True},
             "run_codeocean_pipeline": {"skip_task": True},
+            "remove_source_folders": {"skip_task": True},
         },
     )
 
@@ -236,16 +235,18 @@ def submit_exaspim_job(
 
 
 def test_submit_exaspim_job():
+    # dataset_name = "exaSPIM_718162_2026-01-29_19-28-50"
+    dataset_name = "exaSPIM_785688_2026-02-19_08-34-14"
     data_dir = (
-        "/allen/aind/stage/exaSPIM/"
-        "exaSPIM_683791-screen_2026-01-26_14-53-41/exaSPIM"
+        f"/allen/aind/stage/exaSPIM/"
+        f"{dataset_name}/exaSPIM"
     )
 
     submit_exaspim_job(
         source=data_dir,
         project_name="MSMA Platform",
-        subject_id="683791-screen",
-        single_tile_upload=True,  # Set to True for testing with a single tile
+        subject_id="785688",
+        single_tile_upload=False,  # Set to True for testing with a single tile
     )
 
 

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -78,7 +78,6 @@ def _estimate_resources(
     )  # from profiling, seems to need at least this much per CPU regardless of tile size
 
     memory_per_cpu = min(
-        
         max(estimated_mem, MIN_RAM_MB // CPUS_PER_NODE),
         MAX_RAM_MB // CPUS_PER_NODE,
     )
@@ -238,10 +237,7 @@ def submit_exaspim_job(
 def test_submit_exaspim_job():
     # dataset_name = "exaSPIM_718162_2026-01-29_19-28-50"
     dataset_name = "exaSPIM_785688_2026-02-19_08-34-14"
-    data_dir = (
-        f"/allen/aind/stage/exaSPIM/"
-        f"{dataset_name}/exaSPIM"
-    )
+    data_dir = f"/allen/aind/stage/exaSPIM/" f"{dataset_name}/exaSPIM"
 
     submit_exaspim_job(
         source=data_dir,

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -29,7 +29,7 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-2bd972f"
+IMAGE_VERSION = "dev-e057957"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
 JOB_TYPE = "default"  # registered job type on the dev cluster
@@ -78,6 +78,7 @@ def _estimate_resources(
     )  # from profiling, seems to need at least this much per CPU regardless of tile size
 
     memory_per_cpu = min(
+        
         max(estimated_mem, MIN_RAM_MB // CPUS_PER_NODE),
         MAX_RAM_MB // CPUS_PER_NODE,
     )
@@ -246,7 +247,7 @@ def test_submit_exaspim_job():
         source=data_dir,
         project_name="MSMA Platform",
         subject_id="785688",
-        single_tile_upload=True,  # Set to True for testing with a single tile
+        single_tile_upload=False,  # Set to True for testing with a single tile
     )
 
 

--- a/src/aind_exaspim_data_transformation/__init__.py
+++ b/src/aind_exaspim_data_transformation/__init__.py
@@ -1,6 +1,6 @@
 """Init package"""
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 __authors__ = ["Carson Berry"]
 __author_emails__ = [
     "carson.berry@alleninstitute.org",

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -71,6 +71,16 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
 
         # Important to sort paths so every node computes the same list
         all_stack_paths.sort(key=lambda x: str(x))
+
+        # Filter to single tile if requested
+        if self.job_settings.single_tile_upload and all_stack_paths:
+            logging.info(
+                "Single tile upload mode enabled (file partition mode): "
+                "selecting first tile '%s'",
+                all_stack_paths[0].name,
+            )
+            all_stack_paths = all_stack_paths[:1]
+
         return self.partition_list(
             all_stack_paths, self.job_settings.num_of_partitions
         )
@@ -90,6 +100,15 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
                     all_stack_paths.append(p)
 
         all_stack_paths.sort(key=lambda x: str(x))
+
+        # Filter to single tile if requested
+        if self.job_settings.single_tile_upload and all_stack_paths:
+            logging.info(
+                "Single tile upload mode enabled: selecting first tile '%s'",
+                all_stack_paths[0].name,
+            )
+            all_stack_paths = all_stack_paths[:1]
+
         return all_stack_paths
 
     @staticmethod

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -542,8 +542,11 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
 
         for stack_path in stack_paths:
             with ImarisReader(str(stack_path)) as reader:
+                # Use the authoritative metadata shape (no HDF5 chunk-alignment
+                # padding) so shard enumeration is consistent with the zarr
+                # store shape declared in imaris_to_zarr_distributed().
                 data_shape = cast(
-                    Tuple[int, int, int], tuple(reader.get_shape())
+                    Tuple[int, int, int], reader.get_metadata_shape()
                 )
             for shard_idx in enumerate_shard_indices(data_shape, shard_shape):
                 tasks.append((stack_path, shard_idx))

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -361,7 +361,8 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
 
         # Try to get voxel resolution from acquisition.json if it exists
         # Otherwise, it will be extracted from each Imaris file individually
-        acquisition_path = input_source_path.joinpath("acquisition.json")
+        # acquisition.json lives one level above the input_source (exaSPIM) folder
+        acquisition_path = input_source_path.parent.joinpath("acquisition.json")
 
         voxel_size_zyx = None
         if acquisition_path.exists():
@@ -571,7 +572,8 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             return
 
         # Try to read voxel size from acquisition.json once
-        acquisition_path = Path(self.job_settings.input_source).joinpath(
+        # acquisition.json lives one level above the input_source (exaSPIM) folder
+        acquisition_path = Path(self.job_settings.input_source).parent.joinpath(
             "acquisition.json"
         )
         voxel_size_zyx = None

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -362,7 +362,9 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
         # Try to get voxel resolution from acquisition.json if it exists
         # Otherwise, it will be extracted from each Imaris file individually
         # acquisition.json lives one level above the input_source (exaSPIM) folder
-        acquisition_path = input_source_path.parent.joinpath("acquisition.json")
+        acquisition_path = input_source_path.parent.joinpath(
+            "acquisition.json"
+        )
 
         voxel_size_zyx = None
         if acquisition_path.exists():
@@ -576,9 +578,9 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
 
         # Try to read voxel size from acquisition.json once
         # acquisition.json lives one level above the input_source (exaSPIM) folder
-        acquisition_path = Path(self.job_settings.input_source).parent.joinpath(
-            "acquisition.json"
-        )
+        acquisition_path = Path(
+            self.job_settings.input_source
+        ).parent.joinpath("acquisition.json")
         voxel_size_zyx = None
         if acquisition_path.exists():
             try:

--- a/src/aind_exaspim_data_transformation/models.py
+++ b/src/aind_exaspim_data_transformation/models.py
@@ -127,3 +127,17 @@ class ImarisJobSettings(BasicJobSettings):
         ),
         title="Partition Mode",
     )
+
+    single_tile_upload: bool = Field(
+        default=False,
+        description=(
+            "If True, process only the first tile/file from the dataset. "
+            "The selected tile will still be distributed across workers "
+            "using the configured partitioning strategy (shard or file mode). "
+            "Useful for integration testing and performance validation of "
+            "very large datasets (e.g., 6TB tiles) without processing the "
+            "entire dataset (e.g., 120TB). The first tile is selected after "
+            "deterministic sorting to ensure all workers select the same file."
+        ),
+        title="Single Tile Upload Mode",
+    )

--- a/src/aind_exaspim_data_transformation/utils/io_utils.py
+++ b/src/aind_exaspim_data_transformation/utils/io_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple, cast
 
 import dask.array as da
 import h5py

--- a/src/aind_exaspim_data_transformation/utils/io_utils.py
+++ b/src/aind_exaspim_data_transformation/utils/io_utils.py
@@ -510,9 +510,11 @@ class ImarisReader:
         for lvl in range(1, level + 1):
             next_hdf5: Tuple[int, ...] = self.get_shape(_lvl_data_path(lvl))
             factors = tuple(
-                round(current_hdf5[i] / next_hdf5[i])
-                if next_hdf5[i] > 0
-                else 1
+                (
+                    round(current_hdf5[i] / next_hdf5[i])
+                    if next_hdf5[i] > 0
+                    else 1
+                )
                 for i in range(3)
             )
             current_true = tuple(

--- a/tests/test_imaris_job.py
+++ b/tests/test_imaris_job.py
@@ -1306,5 +1306,83 @@ class TestGetTileTranslationFromAcquisition(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestBuildGlobalShardTaskList(unittest.TestCase):
+    """Tests for _build_global_shard_task_list()."""
+
+    def _make_job(self, shard_size=None):
+        if shard_size is None:
+            shard_size = [512, 512, 512]
+        settings = ImarisJobSettings(
+            input_source="/fake/input",
+            output_directory="/fake/output",
+            num_of_partitions=4,
+            partition_to_process=0,
+            shard_size=shard_size,
+        )
+        return ImarisCompressionJob(job_settings=settings)
+
+    @patch("aind_exaspim_data_transformation.imaris_job.ImarisReader")
+    def test_uses_metadata_shape_not_hdf5_shape(self, mock_reader_cls):
+        """Shard enumeration must use get_metadata_shape(), not get_shape()."""
+        mock_reader = MagicMock()
+        mock_reader_cls.return_value.__enter__.return_value = mock_reader
+        # Simulate padding: HDF5 shape is larger than true image shape
+        mock_reader.get_metadata_shape.return_value = (512, 512, 512)
+        mock_reader.get_shape.return_value = (576, 576, 576)  # padded
+
+        job = self._make_job(shard_size=[512, 512, 512])
+        tasks = job._build_global_shard_task_list([Path("/fake/tile.ims")])
+
+        # Exactly 1 shard for a 512-cube at 512 shard size
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0][1], (0, 0, 0))
+        # get_metadata_shape called; get_shape must NOT be called for shape
+        mock_reader.get_metadata_shape.assert_called_once()
+        mock_reader.get_shape.assert_not_called()
+
+    @patch("aind_exaspim_data_transformation.imaris_job.ImarisReader")
+    def test_shard_count_from_metadata_shape(self, mock_reader_cls):
+        """2x2x2 = 8 shards when metadata shape is exactly 2x shard size."""
+        mock_reader = MagicMock()
+        mock_reader_cls.return_value.__enter__.return_value = mock_reader
+        mock_reader.get_metadata_shape.return_value = (1024, 1024, 1024)
+        mock_reader.get_shape.return_value = (1088, 1088, 1088)  # padded
+
+        job = self._make_job(shard_size=[512, 512, 512])
+        tasks = job._build_global_shard_task_list([Path("/fake/tile.ims")])
+
+        self.assertEqual(len(tasks), 8)
+
+    @patch("aind_exaspim_data_transformation.imaris_job.ImarisReader")
+    def test_multiple_stacks_summed(self, mock_reader_cls):
+        """Tasks from multiple stacks are concatenated correctly."""
+        mock_reader = MagicMock()
+        mock_reader_cls.return_value.__enter__.return_value = mock_reader
+        mock_reader.get_metadata_shape.return_value = (512, 512, 512)
+
+        job = self._make_job(shard_size=[512, 512, 512])
+        stacks = [Path("/fake/tile_a.ims"), Path("/fake/tile_b.ims")]
+        tasks = job._build_global_shard_task_list(stacks)
+
+        self.assertEqual(len(tasks), 2)
+        self.assertEqual(tasks[0][0], stacks[0])
+        self.assertEqual(tasks[1][0], stacks[1])
+
+    @patch("aind_exaspim_data_transformation.imaris_job.ImarisReader")
+    def test_padded_shape_would_give_wrong_count(self, mock_reader_cls):
+        """Confirm the old bug: padded get_shape() would over-count shards."""
+        mock_reader = MagicMock()
+        mock_reader_cls.return_value.__enter__.return_value = mock_reader
+        # True image fits in 1 shard; padded HDF5 shape would spill into 8
+        mock_reader.get_metadata_shape.return_value = (512, 512, 512)
+        mock_reader.get_shape.return_value = (576, 576, 576)  # would give 8
+
+        job = self._make_job(shard_size=[512, 512, 512])
+        tasks = job._build_global_shard_task_list([Path("/fake/tile.ims")])
+
+        # Should get 1 shard (from metadata shape), not 8 (from padded shape)
+        self.assertEqual(len(tasks), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_imaris_to_zarr_parallel.py
+++ b/tests/test_imaris_to_zarr_parallel.py
@@ -1129,6 +1129,7 @@ class TestImarisToZarrDistributed(unittest.TestCase):
         mock_reader = MagicMock()
         mock_reader.get_voxel_size.return_value = ([1.0, 0.5, 0.5], b"um")
         mock_reader.get_shape.return_value = (128, 256, 512)  # Multiple shards
+        mock_reader.get_metadata_shape.return_value = (128, 256, 512)
         mock_reader.get_dtype.return_value = np.dtype("uint16")
         mock_reader.get_chunks.return_value = (32, 64, 128)
         mock_reader_cls.return_value.__enter__ = Mock(return_value=mock_reader)
@@ -1463,6 +1464,10 @@ class TestTranslatePyramidLevels(unittest.TestCase):
             return (128, 256, 512)
 
         mock_reader.get_shape.side_effect = _get_shape
+        mock_reader.get_metadata_shape.return_value = (128, 256, 512)
+        mock_reader.get_true_shape_for_level.side_effect = (
+            lambda lvl: {0: (128, 256, 512), 1: (64, 128, 256), 2: (32, 64, 128)}.get(lvl, (128, 256, 512))
+        )
         mock_reader.get_dtype.return_value = np.dtype("uint16")
         mock_reader.get_chunks.return_value = (32, 64, 128)
         mock_reader_cls.return_value.__enter__ = Mock(return_value=mock_reader)
@@ -1583,6 +1588,10 @@ class TestTranslatePyramidLevels(unittest.TestCase):
             return (128, 256, 512)
 
         mock_reader.get_shape.side_effect = _get_shape
+        mock_reader.get_metadata_shape.return_value = (128, 256, 512)
+        mock_reader.get_true_shape_for_level.side_effect = (
+            lambda lvl: {0: (128, 256, 512), 1: (64, 128, 256)}.get(lvl, (128, 256, 512))
+        )
         mock_reader.get_dtype.return_value = np.dtype("uint16")
         mock_reader.get_chunks.return_value = (32, 64, 128)
         mock_reader_cls.return_value.__enter__ = Mock(return_value=mock_reader)

--- a/tests/test_imaris_to_zarr_parallel.py
+++ b/tests/test_imaris_to_zarr_parallel.py
@@ -1465,9 +1465,11 @@ class TestTranslatePyramidLevels(unittest.TestCase):
 
         mock_reader.get_shape.side_effect = _get_shape
         mock_reader.get_metadata_shape.return_value = (128, 256, 512)
-        mock_reader.get_true_shape_for_level.side_effect = (
-            lambda lvl: {0: (128, 256, 512), 1: (64, 128, 256), 2: (32, 64, 128)}.get(lvl, (128, 256, 512))
-        )
+        mock_reader.get_true_shape_for_level.side_effect = lambda lvl: {
+            0: (128, 256, 512),
+            1: (64, 128, 256),
+            2: (32, 64, 128),
+        }.get(lvl, (128, 256, 512))
         mock_reader.get_dtype.return_value = np.dtype("uint16")
         mock_reader.get_chunks.return_value = (32, 64, 128)
         mock_reader_cls.return_value.__enter__ = Mock(return_value=mock_reader)
@@ -1589,9 +1591,10 @@ class TestTranslatePyramidLevels(unittest.TestCase):
 
         mock_reader.get_shape.side_effect = _get_shape
         mock_reader.get_metadata_shape.return_value = (128, 256, 512)
-        mock_reader.get_true_shape_for_level.side_effect = (
-            lambda lvl: {0: (128, 256, 512), 1: (64, 128, 256)}.get(lvl, (128, 256, 512))
-        )
+        mock_reader.get_true_shape_for_level.side_effect = lambda lvl: {
+            0: (128, 256, 512),
+            1: (64, 128, 256),
+        }.get(lvl, (128, 256, 512))
         mock_reader.get_dtype.return_value = np.dtype("uint16")
         mock_reader.get_chunks.return_value = (32, 64, 128)
         mock_reader_cls.return_value.__enter__ = Mock(return_value=mock_reader)

--- a/tests/test_live_ims_to_zarr.py
+++ b/tests/test_live_ims_to_zarr.py
@@ -836,7 +836,9 @@ class TestLiveImsToZarr(unittest.TestCase):
         import json
 
         zarr_json_path = output_zarr / "0" / "zarr.json"
-        self.assertTrue(zarr_json_path.exists(), "zarr.json should exist at level 0")
+        self.assertTrue(
+            zarr_json_path.exists(), "zarr.json should exist at level 0"
+        )
         with open(zarr_json_path) as f:
             zarr_meta = json.load(f)
 

--- a/tests/test_live_ims_to_zarr.py
+++ b/tests/test_live_ims_to_zarr.py
@@ -22,6 +22,9 @@ from aind_exaspim_data_transformation.compress.imaris_to_zarr import (
 )
 from aind_exaspim_data_transformation.utils.io_utils import ImarisReader
 
+# Limit distributed local test to two shards so it runs in seconds, not hours
+test_shard_indices = [(0, 0, 0), (0, 0, 1)]
+
 
 class ResourceMonitor:
     """Monitor CPU and memory usage during test execution."""
@@ -168,7 +171,7 @@ def timed_operation(
         stats["elapsed_seconds"] = elapsed
 
 
-@unittest.skip("S3 write test - run manually when needed")
+@unittest.skip("Live integration tests — require real IMS data, run manually")
 class TestLiveImsToZarr(unittest.TestCase):
     """Live tests using real IMS files from staging area"""
 
@@ -286,7 +289,7 @@ class TestLiveImsToZarr(unittest.TestCase):
 
             print("✓ All properties read successfully")
 
-    @unittest.skip("S3 write test - run manually when needed")
+    # @unittest.skip("S3 write test - run manually when needed")
     def test_imaris_reader_chunking_strategy(self):
         """Report Imaris chunking strategy and per-dimension chunk counts"""
         if not self.ims_files:
@@ -396,7 +399,7 @@ class TestLiveImsToZarr(unittest.TestCase):
 
             print("\n✓ Pyramid generated successfully")
 
-    @unittest.skip("S3 write test - run manually when needed")
+    @unittest.skip("Full-tile write benchmark — run manually when needed")
     def test_imaris_to_zarr_writer_single_file(self):
         """Test full conversion pipeline: IMS -> Zarr with single file"""
         if not self.ims_files:
@@ -474,7 +477,7 @@ class TestLiveImsToZarr(unittest.TestCase):
             output_size = result.stdout.strip().split()[0]
             print(f"  Output size: {output_size}")
 
-    print("\n✓ Conversion completed successfully")
+        print("\n✓ Conversion completed successfully")
 
     @unittest.skip("S3 write test - run manually when needed")
     def test_imaris_to_zarr_writer_custom_voxel_size(self):
@@ -561,6 +564,13 @@ class TestLiveImsToZarr(unittest.TestCase):
         """Test TensorStore parallel writer with S3 output"""
         if not self.ims_files:
             self.skipTest("No IMS files found in data directory")
+
+        # These tests write to S3 and require explicit opt-in.
+        # Run with: RUN_S3_WRITE_TESTS=1 pytest tests/test_live_ims_to_zarr.py
+        if not os.environ.get("RUN_S3_WRITE_TESTS"):
+            self.skipTest(
+                "S3 write tests disabled — set RUN_S3_WRITE_TESTS=1 to enable"
+            )
 
         ims_file = self.ims_files[0]
 
@@ -651,6 +661,13 @@ class TestLiveImsToZarr(unittest.TestCase):
         if not self.ims_files:
             self.skipTest("No IMS files found in data directory")
 
+        # These tests write to S3 and require explicit opt-in.
+        # Run with: RUN_S3_WRITE_TESTS=1 pytest tests/test_live_ims_to_zarr.py
+        if not os.environ.get("RUN_S3_WRITE_TESTS"):
+            self.skipTest(
+                "S3 write tests disabled — set RUN_S3_WRITE_TESTS=1 to enable"
+            )
+
         ims_file = self.ims_files[0]
 
         # S3 test configuration
@@ -734,7 +751,6 @@ class TestLiveImsToZarr(unittest.TestCase):
 
         print("\n✓ Multi-level S3 upload completed successfully")
 
-    @unittest.skip("Distributed test - run manually when needed")
     def test_imaris_to_zarr_distributed_local(self):
         """Test distributed worker-centric conversion to local filesystem"""
         if not self.ims_files:
@@ -753,29 +769,33 @@ class TestLiveImsToZarr(unittest.TestCase):
         chunk_shape = (128, 128, 128)
         shard_shape = (256, 256, 256)  # ~32MB per shard for uint16
         n_lvls = 3
+        stack_name = f"{ims_file.stem}.ome.zarr"
 
         print(f"  Chunk shape: {chunk_shape}")
         print(f"  Shard shape: {shard_shape}")
         print(f"  Pyramid levels: {n_lvls}")
         print(f"  translate_pyramid_levels: True")
 
-        # Get shard info before conversion
+        # Use metadata shape (no HDF5 padding) — this is what the zarr store
+        # will be created with, and must match the shard enumeration.
         with ImarisReader(str(ims_file)) as reader:
-            shape = reader.get_shape()
-            print(f"  Data shape: {shape}")
+            metadata_shape = reader.get_metadata_shape()
+            hdf5_shape = reader.get_shape()
+            print(f"  Metadata shape (true): {metadata_shape}")
+            print(f"  HDF5 shape (padded):   {hdf5_shape}")
 
-        # Calculate expected shards
+        # Calculate expected shards from the true (unpadded) shape
         import math
 
         shard_grid = tuple(
-            math.ceil(s / sh) for s, sh in zip(shape, shard_shape)
+            math.ceil(s / sh) for s, sh in zip(metadata_shape, shard_shape)
         )
         total_shards = shard_grid[0] * shard_grid[1] * shard_grid[2]
         print(f"  Shard grid: {shard_grid} = {total_shards} total shards")
 
         # Run conversion WITHOUT Dask client (sequential for testing)
         with timed_operation(
-            f"Distributed IMS to Zarr - sequential ({ims_file.name})",
+            f"Distributed IMS to Zarr - 2 shards ({ims_file.name})",
             interval=0.5,
         ) as stats:
             result_path = imaris_to_zarr_distributed(
@@ -786,29 +806,50 @@ class TestLiveImsToZarr(unittest.TestCase):
                 shard_shape=shard_shape,
                 n_lvls=n_lvls,
                 channel_name=ims_file.stem,
-                stack_name=f"{ims_file.stem}_distributed.ome.zarr",
+                stack_name=stack_name,
                 codec="zstd",
                 codec_level=3,
                 bucket_name=None,  # Local filesystem
                 dask_client=None,  # Sequential processing
                 translate_pyramid_levels=True,
+                shard_indices=test_shard_indices,
             )
 
-        # Calculate throughput
         if stats.get("elapsed_seconds", 0) > 0:
-            throughput = input_size_gb / stats["elapsed_seconds"]
-            print(f"\n  📈 Throughput: {throughput:.2f} GB/s")
+            print(f"\n  Elapsed: {stats['elapsed_seconds']:.2f}s")
             print(
                 f"  Peak memory: {stats.get('memory_mb', {}).get('max', 0):.1f} MB"
             )
 
         print(f"  Result path: {result_path}")
 
-        # Verify the output exists
-        output_path = Path(result_path)
+        # Verify the zarr store was created
+        output_zarr = self.output_dir / stack_name
         self.assertTrue(
-            output_path.exists() or result_path.startswith("s3://"),
-            f"Output path should exist: {result_path}",
+            output_zarr.exists(),
+            f"Output zarr should exist at {output_zarr}",
+        )
+
+        # Verify the zarr.json metadata declares the UNPADDED shape.
+        # This is the core assertion for the get_metadata_shape() fix:
+        # the zarr store shape must match metadata_shape, not hdf5_shape.
+        import json
+
+        zarr_json_path = output_zarr / "0" / "zarr.json"
+        self.assertTrue(zarr_json_path.exists(), "zarr.json should exist at level 0")
+        with open(zarr_json_path) as f:
+            zarr_meta = json.load(f)
+
+        stored_shape = tuple(zarr_meta["shape"])
+        # zarr.json shape is [1, 1, Z, Y, X] — compare the last 3 dims
+        stored_zyx = stored_shape[-3:]
+        print(f"  zarr.json shape (ZYX): {stored_zyx}")
+        print(f"  Expected (metadata):   {metadata_shape}")
+        self.assertEqual(
+            stored_zyx,
+            metadata_shape,
+            f"zarr store shape {stored_zyx} must equal metadata_shape "
+            f"{metadata_shape}, not padded HDF5 shape {hdf5_shape}",
         )
 
         print("\n✓ Distributed conversion (sequential) completed successfully")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,6 +142,50 @@ class TestImarisJobSettings(unittest.TestCase):
             )
             self.assertEqual(settings.downsample_mode, mode)
 
+    def test_single_tile_upload_default(self):
+        """Test single_tile_upload defaults to False"""
+        settings = ImarisJobSettings(
+            input_source="/path/to/input",
+            output_directory="/path/to/output",
+            num_of_partitions=4,
+            partition_to_process=0,
+        )
+        self.assertFalse(settings.single_tile_upload)
+
+    def test_single_tile_upload_explicit_true(self):
+        """Test single_tile_upload can be set to True"""
+        settings = ImarisJobSettings(
+            input_source="/path/to/input",
+            output_directory="/path/to/output",
+            num_of_partitions=4,
+            partition_to_process=0,
+            single_tile_upload=True,
+        )
+        self.assertTrue(settings.single_tile_upload)
+
+    def test_single_tile_upload_explicit_false(self):
+        """Test single_tile_upload can be explicitly set to False"""
+        settings = ImarisJobSettings(
+            input_source="/path/to/input",
+            output_directory="/path/to/output",
+            num_of_partitions=4,
+            partition_to_process=0,
+            single_tile_upload=False,
+        )
+        self.assertFalse(settings.single_tile_upload)
+
+    def test_single_tile_upload_json_parsing(self):
+        """Test single_tile_upload parses correctly from JSON"""
+        json_config = """{
+            "input_source": "/path/to/input",
+            "output_directory": "/path/to/output",
+            "num_of_partitions": 4,
+            "partition_to_process": 0,
+            "single_tile_upload": true
+        }"""
+        settings = ImarisJobSettings.model_validate_json(json_config)
+        self.assertTrue(settings.single_tile_upload)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This release includes shard-level parallel uploading, including a test upload script that consistently attains better than 200GB/min upload speed on terabyte scale datasets. To date, no stress tests have failed at the tensorstore zarr write stage. 

This release adds the useful development feature to upload a single tile (the first) from a dataset if indicated. 

This release patches a major bug which placed tile positions at incorrect orientations (due to reading tile position from imaris files) by reading tile position from acquisition.json files. 

This release patches a minor bug which would display additional empty space around data volumes in one or more axes when displayed in neuroglancer.

