### PR TITLE
Feat upgrade metadata

### DIFF
--- a/docs/examples/acquisition.json
+++ b/docs/examples/acquisition.json
@@ -1,0 +1,137 @@
+{
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+   "schema_version": "1.0.4",
+   "protocol_id": [],
+   "experimenter_full_name": [
+      "adam glaser"
+   ],
+   "specimen_id": "819682-screen",
+   "subject_id": "819682-screen",
+   "instrument_id": "",
+   "calibrations": [],
+   "maintenance": [],
+   "session_start_time": "2026-03-11T14:42:37.204462-07:00",
+   "session_end_time": "2026-03-11T14:59:38.243638-07:00",
+   "session_type": null,
+   "tiles": [
+      {
+         "coordinate_transformations": [
+            {
+               "type": "scale",
+               "scale": [
+                  "15.04",
+                  "15.04",
+                  "20.0"
+               ]
+            },
+            {
+               "type": "translation",
+               "translation": [
+                  "-55.4196",
+                  "7.605",
+                  "-24.6392"
+               ]
+            }
+         ],
+         "file_name": "right_000000_ch_488.ims",
+         "channel": {
+            "channel_name": "488",
+            "light_source_name": "488 nm",
+            "filter_names": [],
+            "detector_name": "vnp-604mx",
+            "additional_device_names": [
+               "camera",
+               "left_right_flip_mount"
+            ],
+            "excitation_wavelength": 488,
+            "excitation_wavelength_unit": "nanometer",
+            "excitation_power": 197.0,
+            "excitation_power_unit": "milliwatt",
+            "filter_wheel_index": 0,
+            "dilation": null,
+            "dilation_unit": "pixel",
+            "description": null
+         },
+         "notes": null,
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degrees",
+         "acquisition_start_time": null,
+         "acquisition_end_time": null
+      },
+      {
+         "coordinate_transformations": [
+            {
+               "type": "scale",
+               "scale": [
+                  "15.04",
+                  "15.04",
+                  "20.0"
+               ]
+            },
+            {
+               "type": "translation",
+               "translation": [
+                  "-55.4196",
+                  "7.605",
+                  "-24.6392"
+               ]
+            }
+         ],
+         "file_name": "left_000001_ch_488.ims",
+         "channel": {
+            "channel_name": "488",
+            "light_source_name": "488 nm",
+            "filter_names": [],
+            "detector_name": "vnp-604mx",
+            "additional_device_names": [
+               "camera",
+               "left_right_flip_mount"
+            ],
+            "excitation_wavelength": 488,
+            "excitation_wavelength_unit": "nanometer",
+            "excitation_power": 197.0,
+            "excitation_power_unit": "milliwatt",
+            "filter_wheel_index": 0,
+            "dilation": null,
+            "dilation_unit": "pixel",
+            "description": null
+         },
+         "notes": null,
+         "imaging_angle": 0,
+         "imaging_angle_unit": "degrees",
+         "acquisition_start_time": null,
+         "acquisition_end_time": null
+      }
+   ],
+   "axes": [
+      {
+         "name": "X",
+         "direction": "Inferior_to_superior",
+         "dimension": 2,
+         "unit": "micrometer"
+      },
+      {
+         "name": "Y",
+         "direction": "Anterior_to_posterior",
+         "dimension": 1,
+         "unit": "micrometer"
+      },
+      {
+         "name": "Z",
+         "direction": "Left_to_right",
+         "dimension": 0,
+         "unit": "micrometer"
+      }
+   ],
+   "chamber_immersion": {
+      "medium": "other",
+      "refractive_index": "1.33"
+   },
+   "sample_immersion": null,
+   "active_objectives": null,
+   "local_storage_directory": "D:\\exaSPIM_819682-screen_2026-03-11_14-42-37",
+   "external_storage_directory": "Z:\\stage\\exaSPIM\\exaSPIM_819682-screen_2026-03-11_14-42-37",
+   "processing_steps": [],
+   "software": [],
+   "notes": null
+}

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -24,6 +24,10 @@ from aind_data_transfer_service.models.core import (
     UploadJobConfigsV2,
 )
 
+from aind_exaspim_data_transformation.upgrade_metadata import (
+    upgrade_metadata,
+)
+
 # from aind_data_schema_models.platforms import Platform
 
 
@@ -32,6 +36,7 @@ IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
 IMAGE_VERSION = "dev-e057957"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
+S3_BUCKET_PREFIX = "aind-open-data-dev"  # actual S3 bucket name for dev
 JOB_TYPE = "default"  # registered job type on the dev cluster
 
 # Resource limits
@@ -114,11 +119,21 @@ def _derive_subject_id(path: str) -> str:
     return basename
 
 
+def _derive_dataset_name(source: str) -> str:
+    """Derive the dataset name from the source directory path.
+
+    Expects a path like ``/allen/aind/stage/exaSPIM/<dataset>/exaSPIM``.
+    Returns the ``<dataset>`` component.
+    """
+    return os.path.basename(os.path.dirname(os.path.normpath(source)))
+
+
 def submit_exaspim_job(
     source: str,
     project_name: str = "MSMA Platform",
     subject_id: str | None = None,
     single_tile_upload: bool = False,
+    run_metadata_upgrade: bool = True,
 ) -> None:
     """Build and POST an ExaSPIM transformation job.
 
@@ -133,9 +148,28 @@ def submit_exaspim_job(
     single_tile_upload : bool
         If True, only process the first tile for integration testing.
         Default is False (process all tiles).
+    run_metadata_upgrade : bool
+        If True (default), upgrade v1 metadata files to v2.5+ and
+        upload them to S3 before submitting the transformation job.
     """
     if subject_id is None:
         subject_id = _derive_subject_id(source)
+
+    # ── Upgrade v1 metadata → v2.5+ and upload to S3 ───────────────
+    if run_metadata_upgrade:
+        dataset_name = _derive_dataset_name(source)
+        s3_location = f"s3://{S3_BUCKET_PREFIX}/{dataset_name}"
+        print(f"Upgrading metadata for {dataset_name} → {s3_location}")
+        try:
+            upgrade_metadata(
+                source_dir=source,
+                s3_location=s3_location,
+            )
+            print("Metadata upgrade complete.")
+        except Exception as exc:
+            print(f"WARNING: Metadata upgrade failed: {exc}")
+            print("Continuing with job submission…")
+    # ────────────────────────────────────────────────────────────────
 
     acq_datetime = _parse_acq_datetime(source)
     ims_files = _discover_ims_files(source)
@@ -244,6 +278,7 @@ def test_submit_exaspim_job():
         project_name="MSMA Platform",
         subject_id="785688",
         single_tile_upload=False,  # Set to True for testing with a single tile
+        run_metadata_upgrade=True,  # Upgrade v1 metadata files to v2.5+
     )
 
 
@@ -277,6 +312,11 @@ def main():
         action="store_true",
         help="Process only the first tile (for integration testing).",
     )
+    parser.add_argument(
+        "--no-metadata-upgrade",
+        action="store_true",
+        help="Skip upgrading v1 metadata files to v2.5+.",
+    )
     args = parser.parse_args()
 
     submit_exaspim_job(
@@ -284,6 +324,7 @@ def main():
         project_name=args.project_name,
         subject_id=args.subject_id,
         single_tile_upload=args.single_tile,
+        run_metadata_upgrade=not args.no_metadata_upgrade,
     )
 
 

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -36,7 +36,7 @@ IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
 IMAGE_VERSION = "dev-e057957"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
-S3_BUCKET_PREFIX = "aind-open-data-dev"  # actual S3 bucket name for dev
+S3_BUCKET_PREFIX = "aind-open-data-dev-u5u0i5"  # actual S3 bucket name for dev
 JOB_TYPE = "default"  # registered job type on the dev cluster
 
 # Resource limits
@@ -270,13 +270,13 @@ def submit_exaspim_job(
 
 def test_submit_exaspim_job():
     # dataset_name = "exaSPIM_718162_2026-01-29_19-28-50"
-    dataset_name = "exaSPIM_785688_2026-02-19_08-34-14"
-    data_dir = f"/allen/aind/stage/exaSPIM/" f"{dataset_name}/exaSPIM"
+    dataset_name = "exaSPIM_819682-screen_2026-03-11_14-42-37"
+    data_dir = f"/allen/aind/stage/exaSPIM/{dataset_name}/exaSPIM"
 
     submit_exaspim_job(
         source=data_dir,
         project_name="MSMA Platform",
-        subject_id="785688",
+        subject_id="819682-screen",
         single_tile_upload=False,  # Set to True for testing with a single tile
         run_metadata_upgrade=True,  # Upgrade v1 metadata files to v2.5+
     )

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -78,7 +78,6 @@ def _estimate_resources(
     )  # from profiling, seems to need at least this much per CPU regardless of tile size
 
     memory_per_cpu = min(
-        
         max(estimated_mem, MIN_RAM_MB // CPUS_PER_NODE),
         MAX_RAM_MB // CPUS_PER_NODE,
     )
@@ -238,10 +237,7 @@ def submit_exaspim_job(
 def test_submit_exaspim_job():
     # dataset_name = "exaSPIM_718162_2026-01-29_19-28-50"
     dataset_name = "exaSPIM_785688_2026-02-19_08-34-14"
-    data_dir = (
-        f"/allen/aind/stage/exaSPIM/"
-        f"{dataset_name}/exaSPIM"
-    )
+    data_dir = f"/allen/aind/stage/exaSPIM/" f"{dataset_name}/exaSPIM"
 
     submit_exaspim_job(
         source=data_dir,

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -29,7 +29,7 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-2bd972f"
+IMAGE_VERSION = "dev-e057957"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
 JOB_TYPE = "default"  # registered job type on the dev cluster
@@ -78,6 +78,7 @@ def _estimate_resources(
     )  # from profiling, seems to need at least this much per CPU regardless of tile size
 
     memory_per_cpu = min(
+        
         max(estimated_mem, MIN_RAM_MB // CPUS_PER_NODE),
         MAX_RAM_MB // CPUS_PER_NODE,
     )
@@ -246,7 +247,7 @@ def test_submit_exaspim_job():
         source=data_dir,
         project_name="MSMA Platform",
         subject_id="785688",
-        single_tile_upload=True,  # Set to True for testing with a single tile
+        single_tile_upload=False,  # Set to True for testing with a single tile
     )
 
 

--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -160,15 +160,11 @@ def submit_exaspim_job(
         dataset_name = _derive_dataset_name(source)
         s3_location = f"s3://{S3_BUCKET_PREFIX}/{dataset_name}"
         print(f"Upgrading metadata for {dataset_name} → {s3_location}")
-        try:
-            upgrade_metadata(
-                source_dir=source,
-                s3_location=s3_location,
-            )
-            print("Metadata upgrade complete.")
-        except Exception as exc:
-            print(f"WARNING: Metadata upgrade failed: {exc}")
-            print("Continuing with job submission…")
+        upgrade_metadata(
+            source_dir=source,
+            s3_location=s3_location,
+        )
+        print("Metadata upgrade complete.")
     # ────────────────────────────────────────────────────────────────
 
     acq_datetime = _parse_acq_datetime(source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "pydantic-settings>=2.0.0", 
     "tensorstore==0.1.80",
     "psutil==7.2.2", 
-    "boto3==1.42.36"
+    "boto3==1.42.36",
+    "aind-metadata-upgrader>=0.8.0"
 ]
 
 [tool.setuptools]

--- a/src/aind_exaspim_data_transformation/__init__.py
+++ b/src/aind_exaspim_data_transformation/__init__.py
@@ -1,6 +1,6 @@
 """Init package"""
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 __authors__ = ["Carson Berry"]
 __author_emails__ = [
     "carson.berry@alleninstitute.org",

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -362,7 +362,9 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
         # Try to get voxel resolution from acquisition.json if it exists
         # Otherwise, it will be extracted from each Imaris file individually
         # acquisition.json lives one level above the input_source (exaSPIM) folder
-        acquisition_path = input_source_path.parent.joinpath("acquisition.json")
+        acquisition_path = input_source_path.parent.joinpath(
+            "acquisition.json"
+        )
 
         voxel_size_zyx = None
         if acquisition_path.exists():
@@ -576,9 +578,9 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
 
         # Try to read voxel size from acquisition.json once
         # acquisition.json lives one level above the input_source (exaSPIM) folder
-        acquisition_path = Path(self.job_settings.input_source).parent.joinpath(
-            "acquisition.json"
-        )
+        acquisition_path = Path(
+            self.job_settings.input_source
+        ).parent.joinpath("acquisition.json")
         voxel_size_zyx = None
         if acquisition_path.exists():
             try:

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -1,0 +1,240 @@
+"""
+Upgrade aind-data-schema metadata files from v1 to v2.5+.
+
+Reads ``acquisition.json`` (and optionally ``instrument.json``) from a
+local ExaSPIM dataset directory, upgrades them using
+``aind-metadata-upgrader``, backs up the originals to S3 under
+``derived/``, and writes the upgraded versions to the S3 dataset root.
+
+Usage
+-----
+    python -m aind_exaspim_data_transformation.upgrade_metadata \
+        --source-dir /allen/aind/stage/exaSPIM/<dataset>/exaSPIM \
+        --s3-location s3://aind-open-data/<dataset_name>
+"""
+
+import argparse
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from packaging import version
+
+from aind_exaspim_data_transformation.utils import utils
+
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "DEBUG"))
+logger = logging.getLogger(__name__)
+
+# Metadata files we know how to upgrade
+_METADATA_FILES = ("acquisition.json", "instrument.json")
+
+# Schema version threshold — anything below this gets upgraded
+_V2_THRESHOLD = "2.0.0"
+
+
+def _load_metadata_file(path: Path) -> dict | None:
+    """Load a JSON metadata file, returning *None* if missing/empty."""
+    data = utils.read_json_as_dict(path)
+    if not data:
+        return None
+    return data
+
+
+def _needs_upgrade(data: dict) -> bool:
+    """Return True when the schema_version in *data* is below v2."""
+    sv = data.get("schema_version", "0.0.0")
+    return version.parse(sv) < version.parse(_V2_THRESHOLD)
+
+
+def _write_json_to_tempfile(data: dict) -> Path:
+    """Serialize *data* to a temporary JSON file and return its path.
+
+    The caller is responsible for cleaning up the temp file.
+    """
+    fd, tmp_path = tempfile.mkstemp(suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(data, fh, indent=3, default=str)
+    except Exception:
+        os.close(fd)
+        raise
+    return Path(tmp_path)
+
+
+def _backup_original_to_s3(
+    local_path: Path, s3_location: str, filename: str
+) -> None:
+    """Copy a local file to ``{s3_location}/derived/v1_{filename}``."""
+    s3_dest = f"{s3_location.rstrip('/')}/derived/v1_{filename}"
+    logger.info("Backing up %s → %s", local_path, s3_dest)
+    utils.copy_file_to_s3(local_path, s3_dest)
+
+
+def _upload_upgraded_to_s3(
+    data: dict, s3_location: str, filename: str
+) -> None:
+    """Write *data* to a temp file and upload to S3 dataset root."""
+    tmp = _write_json_to_tempfile(data)
+    try:
+        s3_dest = f"{s3_location.rstrip('/')}/{filename}"
+        logger.info("Uploading upgraded %s → %s", filename, s3_dest)
+        utils.copy_file_to_s3(tmp, s3_dest)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def upgrade_metadata(source_dir: str, s3_location: str) -> None:
+    """Upgrade v1 metadata files and upload results to S3.
+
+    Parameters
+    ----------
+    source_dir : str
+        Path to the folder containing ``.ims`` files (the ``input_source``).
+        Metadata files are expected one level up, e.g.::
+
+            /allen/aind/stage/exaSPIM/<dataset>/acquisition.json
+            /allen/aind/stage/exaSPIM/<dataset>/exaSPIM/  ← source_dir
+
+    s3_location : str
+        Full S3 URI of the dataset root, e.g.
+        ``s3://aind-open-data/exaSPIM_12345_2026-01-01_00-00-00``.
+    """
+    # Lazy import — only needed when we actually upgrade
+    from aind_metadata_upgrader.upgrade import Upgrade
+
+    metadata_dir = Path(source_dir).parent
+    logger.info("Looking for metadata in %s", metadata_dir)
+
+    # ── Load acquisition.json (required) ────────────────────────────
+    acq_path = metadata_dir / "acquisition.json"
+    acq_data = _load_metadata_file(acq_path)
+
+    if acq_data is None:
+        logger.warning(
+            "No acquisition.json found at %s — nothing to upgrade.",
+            acq_path,
+        )
+        return
+
+    if not _needs_upgrade(acq_data):
+        logger.info(
+            "acquisition.json is already schema_version %s (>= %s), "
+            "skipping upgrade.",
+            acq_data.get("schema_version"),
+            _V2_THRESHOLD,
+        )
+        return
+
+    logger.info(
+        "acquisition.json is schema_version %s — upgrading …",
+        acq_data.get("schema_version"),
+    )
+
+    # ── Load instrument.json (optional) ─────────────────────────────
+    inst_path = metadata_dir / "instrument.json"
+    inst_data = _load_metadata_file(inst_path)
+
+    if inst_data is None:
+        logger.info(
+            "No instrument.json found at %s — proceeding without it.",
+            inst_path,
+        )
+
+    # ── Build upgrader input record ─────────────────────────────────
+    record: dict = {"acquisition": acq_data}
+    if inst_data is not None:
+        record["instrument"] = inst_data
+
+    # skip_metadata_validation=True because we only have partial metadata
+    # (no subject, procedures, data_description, etc.)
+    upgraded = Upgrade(record, skip_metadata_validation=True)
+
+    # ── Extract upgraded dicts ──────────────────────────────────────
+    upgraded_acq = None
+    if upgraded.metadata.acquisition is not None:
+        upgraded_acq = upgraded.metadata.acquisition.model_dump(
+            mode="json", exclude_none=True
+        )
+
+    upgraded_inst = None
+    if (
+        inst_data is not None
+        and upgraded.metadata.instrument is not None
+    ):
+        upgraded_inst = upgraded.metadata.instrument.model_dump(
+            mode="json", exclude_none=True
+        )
+
+    # ── Backup originals to S3 derived/ ─────────────────────────────
+    _backup_original_to_s3(acq_path, s3_location, "acquisition.json")
+
+    if inst_data is not None:
+        _backup_original_to_s3(
+            inst_path, s3_location, "instrument.json"
+        )
+
+    # ── Upload upgraded files to S3 root ────────────────────────────
+    if upgraded_acq is not None:
+        _upload_upgraded_to_s3(
+            upgraded_acq, s3_location, "acquisition.json"
+        )
+        logger.info(
+            "Upgraded acquisition.json to schema_version %s",
+            upgraded_acq.get("schema_version"),
+        )
+    else:
+        logger.warning(
+            "Upgrader did not produce an upgraded acquisition — "
+            "skipping upload."
+        )
+
+    if upgraded_inst is not None:
+        _upload_upgraded_to_s3(
+            upgraded_inst, s3_location, "instrument.json"
+        )
+        logger.info(
+            "Upgraded instrument.json to schema_version %s",
+            upgraded_inst.get("schema_version"),
+        )
+
+    logger.info("Metadata upgrade complete.")
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Upgrade ExaSPIM metadata files (acquisition.json, "
+            "instrument.json) from aind-data-schema v1 to v2.5+."
+        ),
+    )
+    parser.add_argument(
+        "--source-dir",
+        type=str,
+        required=True,
+        help=(
+            "Path to the folder containing .ims files (the input_source). "
+            "Metadata files are expected one level up."
+        ),
+    )
+    parser.add_argument(
+        "--s3-location",
+        type=str,
+        required=True,
+        help=(
+            "Full S3 URI of the dataset root, e.g. "
+            "s3://aind-open-data/exaSPIM_12345_2026-01-01_00-00-00"
+        ),
+    )
+    args = parser.parse_args()
+
+    upgrade_metadata(
+        source_dir=args.source_dir,
+        s3_location=args.s3_location,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -112,11 +112,10 @@ def upgrade_metadata(source_dir: str, s3_location: str) -> None:
     acq_data = _load_metadata_file(acq_path)
 
     if acq_data is None:
-        logger.warning(
-            "No acquisition.json found at %s — nothing to upgrade.",
-            acq_path,
+        raise FileNotFoundError(
+            f"acquisition.json not found at {acq_path}. "
+            "This file is required for metadata upgrade."
         )
-        return
 
     if not _needs_upgrade(acq_data):
         logger.info(
@@ -185,9 +184,9 @@ def upgrade_metadata(source_dir: str, s3_location: str) -> None:
             upgraded_acq.get("schema_version"),
         )
     else:
-        logger.warning(
-            "Upgrader did not produce an upgraded acquisition — "
-            "skipping upload."
+        raise RuntimeError(
+            "Upgrader did not produce an upgraded acquisition.json. "
+            "Check the input data and upgrader logs above."
         )
 
     if upgraded_inst is not None:

--- a/src/aind_exaspim_data_transformation/utils/io_utils.py
+++ b/src/aind_exaspim_data_transformation/utils/io_utils.py
@@ -510,9 +510,11 @@ class ImarisReader:
         for lvl in range(1, level + 1):
             next_hdf5: Tuple[int, ...] = self.get_shape(_lvl_data_path(lvl))
             factors = tuple(
-                round(current_hdf5[i] / next_hdf5[i])
-                if next_hdf5[i] > 0
-                else 1
+                (
+                    round(current_hdf5[i] / next_hdf5[i])
+                    if next_hdf5[i] > 0
+                    else 1
+                )
                 for i in range(3)
             )
             current_true = tuple(

--- a/tests/test_imaris_to_zarr_parallel.py
+++ b/tests/test_imaris_to_zarr_parallel.py
@@ -1465,9 +1465,11 @@ class TestTranslatePyramidLevels(unittest.TestCase):
 
         mock_reader.get_shape.side_effect = _get_shape
         mock_reader.get_metadata_shape.return_value = (128, 256, 512)
-        mock_reader.get_true_shape_for_level.side_effect = (
-            lambda lvl: {0: (128, 256, 512), 1: (64, 128, 256), 2: (32, 64, 128)}.get(lvl, (128, 256, 512))
-        )
+        mock_reader.get_true_shape_for_level.side_effect = lambda lvl: {
+            0: (128, 256, 512),
+            1: (64, 128, 256),
+            2: (32, 64, 128),
+        }.get(lvl, (128, 256, 512))
         mock_reader.get_dtype.return_value = np.dtype("uint16")
         mock_reader.get_chunks.return_value = (32, 64, 128)
         mock_reader_cls.return_value.__enter__ = Mock(return_value=mock_reader)
@@ -1589,9 +1591,10 @@ class TestTranslatePyramidLevels(unittest.TestCase):
 
         mock_reader.get_shape.side_effect = _get_shape
         mock_reader.get_metadata_shape.return_value = (128, 256, 512)
-        mock_reader.get_true_shape_for_level.side_effect = (
-            lambda lvl: {0: (128, 256, 512), 1: (64, 128, 256)}.get(lvl, (128, 256, 512))
-        )
+        mock_reader.get_true_shape_for_level.side_effect = lambda lvl: {
+            0: (128, 256, 512),
+            1: (64, 128, 256),
+        }.get(lvl, (128, 256, 512))
         mock_reader.get_dtype.return_value = np.dtype("uint16")
         mock_reader.get_chunks.return_value = (32, 64, 128)
         mock_reader_cls.return_value.__enter__ = Mock(return_value=mock_reader)

--- a/tests/test_live_ims_to_zarr.py
+++ b/tests/test_live_ims_to_zarr.py
@@ -836,7 +836,9 @@ class TestLiveImsToZarr(unittest.TestCase):
         import json
 
         zarr_json_path = output_zarr / "0" / "zarr.json"
-        self.assertTrue(zarr_json_path.exists(), "zarr.json should exist at level 0")
+        self.assertTrue(
+            zarr_json_path.exists(), "zarr.json should exist at level 0"
+        )
         with open(zarr_json_path) as f:
             zarr_meta = json.load(f)
 

--- a/tests/test_upgrade_metadata.py
+++ b/tests/test_upgrade_metadata.py
@@ -1,0 +1,322 @@
+"""Tests for the metadata upgrade module."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from aind_exaspim_data_transformation.upgrade_metadata import (
+    _load_metadata_file,
+    _needs_upgrade,
+    _write_json_to_tempfile,
+    upgrade_metadata,
+)
+
+
+class TestNeedsUpgrade(unittest.TestCase):
+    """Tests for _needs_upgrade helper."""
+
+    def test_v1_needs_upgrade(self):
+        self.assertTrue(_needs_upgrade({"schema_version": "1.0.4"}))
+
+    def test_v0_needs_upgrade(self):
+        self.assertTrue(_needs_upgrade({"schema_version": "0.5.0"}))
+
+    def test_missing_version_needs_upgrade(self):
+        self.assertTrue(_needs_upgrade({}))
+
+    def test_v2_does_not_need_upgrade(self):
+        self.assertFalse(_needs_upgrade({"schema_version": "2.0.0"}))
+
+    def test_v2_5_does_not_need_upgrade(self):
+        self.assertFalse(_needs_upgrade({"schema_version": "2.5.1"}))
+
+    def test_v3_does_not_need_upgrade(self):
+        self.assertFalse(_needs_upgrade({"schema_version": "3.0.0"}))
+
+
+class TestLoadMetadataFile(unittest.TestCase):
+    """Tests for _load_metadata_file helper."""
+
+    def test_returns_none_for_missing_file(self):
+        result = _load_metadata_file(Path("/nonexistent/path.json"))
+        self.assertIsNone(result)
+
+    def test_loads_valid_json(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump({"schema_version": "1.0.0", "key": "value"}, f)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            result = _load_metadata_file(path)
+            self.assertIsNotNone(result)
+            self.assertEqual(result["schema_version"], "1.0.0")
+        finally:
+            path.unlink()
+
+    def test_returns_none_for_empty_file(self):
+        """An empty file should yield an empty dict → None."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            f.write("")
+            path = Path(f.name)
+
+        try:
+            result = _load_metadata_file(path)
+            self.assertIsNone(result)
+        finally:
+            path.unlink()
+
+
+class TestWriteJsonToTempfile(unittest.TestCase):
+    """Tests for _write_json_to_tempfile helper."""
+
+    def test_creates_valid_json_file(self):
+        data = {"schema_version": "2.5.0", "tiles": []}
+        tmp = _write_json_to_tempfile(data)
+        try:
+            self.assertTrue(tmp.exists())
+            loaded = json.loads(tmp.read_text())
+            self.assertEqual(loaded["schema_version"], "2.5.0")
+        finally:
+            tmp.unlink()
+
+
+EXAMPLE_V1_ACQ = Path(__file__).resolve().parent.parent / (
+    "docs/examples/acquisition.json"
+)
+
+
+class TestUpgradeMetadata(unittest.TestCase):
+    """Integration-style tests for upgrade_metadata (with mocked I/O)."""
+
+    def _make_source_dir(self, tmpdir, acq_data=None, inst_data=None):
+        """Create a fake dataset directory structure.
+
+        Returns the source_dir path (equivalent to ``input_source``).
+        """
+        dataset_dir = Path(tmpdir) / "exaSPIM_test_2026-01-01_00-00-00"
+        source_dir = dataset_dir / "exaSPIM"
+        source_dir.mkdir(parents=True)
+
+        if acq_data is not None:
+            (dataset_dir / "acquisition.json").write_text(
+                json.dumps(acq_data, indent=2)
+            )
+        if inst_data is not None:
+            (dataset_dir / "instrument.json").write_text(
+                json.dumps(inst_data, indent=2)
+            )
+
+        return str(source_dir)
+
+    def test_skips_when_no_acquisition(self):
+        """Should log warning and return early when acquisition.json is
+        missing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_source_dir(tmpdir)
+
+            with patch(
+                "aind_exaspim_data_transformation.upgrade_metadata"
+                ".utils.copy_file_to_s3"
+            ) as mock_cp:
+                upgrade_metadata(source_dir, "s3://bucket/dataset")
+                mock_cp.assert_not_called()
+
+    def test_skips_when_already_v2(self):
+        """Should skip silently when acquisition is already v2+."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_source_dir(
+                tmpdir,
+                acq_data={"schema_version": "2.5.0", "data_streams": []},
+            )
+
+            with patch(
+                "aind_exaspim_data_transformation.upgrade_metadata"
+                ".utils.copy_file_to_s3"
+            ) as mock_cp:
+                upgrade_metadata(source_dir, "s3://bucket/dataset")
+                mock_cp.assert_not_called()
+
+    @patch(
+        "aind_exaspim_data_transformation.upgrade_metadata"
+        ".utils.copy_file_to_s3"
+    )
+    def test_upgrades_v1_acquisition(self, mock_cp):
+        """Should call the upgrader and upload files for v1 data."""
+        v1_acq = {"schema_version": "1.0.4", "tiles": [], "axes": []}
+
+        fake_upgraded_acq = MagicMock()
+        fake_upgraded_acq.model_dump.return_value = {
+            "schema_version": "2.5.1",
+            "data_streams": [],
+        }
+
+        fake_metadata = MagicMock()
+        fake_metadata.acquisition = fake_upgraded_acq
+        fake_metadata.instrument = None
+
+        mock_upgrade_instance = MagicMock()
+        mock_upgrade_instance.metadata = fake_metadata
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_source_dir(tmpdir, acq_data=v1_acq)
+
+            with patch(
+                "aind_metadata_upgrader.upgrade.Upgrade",
+                return_value=mock_upgrade_instance,
+            ) as mock_upgrade_cls:
+                upgrade_metadata(source_dir, "s3://bucket/dataset")
+
+                # Upgrader was called with the v1 record
+                mock_upgrade_cls.assert_called_once()
+                call_args = mock_upgrade_cls.call_args
+                self.assertIn("acquisition", call_args[0][0])
+                self.assertTrue(call_args[1]["skip_metadata_validation"])
+
+                # Should have uploaded: backup v1 acq + upgraded acq = 2 calls
+                self.assertEqual(mock_cp.call_count, 2)
+
+                # Check backup went to derived/
+                backup_call = mock_cp.call_args_list[0]
+                self.assertIn(
+                    "derived/v1_acquisition.json", backup_call[0][1]
+                )
+
+                # Check upgraded went to root
+                upload_call = mock_cp.call_args_list[1]
+                self.assertIn("acquisition.json", upload_call[0][1])
+                self.assertNotIn("derived", upload_call[0][1])
+
+    @patch(
+        "aind_exaspim_data_transformation.upgrade_metadata"
+        ".utils.copy_file_to_s3"
+    )
+    def test_upgrades_both_acquisition_and_instrument(self, mock_cp):
+        """Should process both files when both are present."""
+        v1_acq = {"schema_version": "1.0.4", "tiles": [], "axes": []}
+        v1_inst = {
+            "schema_version": "1.0.0",
+            "instrument_id": "exaSPIM",
+            "fluorescence_filters": [],
+            "light_sources": [],
+        }
+
+        fake_upgraded_acq = MagicMock()
+        fake_upgraded_acq.model_dump.return_value = {
+            "schema_version": "2.5.1",
+        }
+        fake_upgraded_inst = MagicMock()
+        fake_upgraded_inst.model_dump.return_value = {
+            "schema_version": "2.5.1",
+        }
+
+        fake_metadata = MagicMock()
+        fake_metadata.acquisition = fake_upgraded_acq
+        fake_metadata.instrument = fake_upgraded_inst
+
+        mock_upgrade_instance = MagicMock()
+        mock_upgrade_instance.metadata = fake_metadata
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_source_dir(
+                tmpdir, acq_data=v1_acq, inst_data=v1_inst
+            )
+
+            with patch(
+                "aind_metadata_upgrader.upgrade.Upgrade",
+                return_value=mock_upgrade_instance,
+            ):
+                upgrade_metadata(source_dir, "s3://bucket/dataset")
+
+                # backup v1_acq + backup v1_inst + upgraded acq + upgraded inst
+                self.assertEqual(mock_cp.call_count, 4)
+
+                s3_dests = [call[0][1] for call in mock_cp.call_args_list]
+                self.assertTrue(
+                    any("derived/v1_acquisition.json" in d for d in s3_dests)
+                )
+                self.assertTrue(
+                    any("derived/v1_instrument.json" in d for d in s3_dests)
+                )
+
+    @patch(
+        "aind_exaspim_data_transformation.upgrade_metadata"
+        ".utils.copy_file_to_s3"
+    )
+    def test_proceeds_without_instrument(self, mock_cp):
+        """Should upgrade acquisition even when instrument.json is absent."""
+        v1_acq = {"schema_version": "1.0.4", "tiles": [], "axes": []}
+
+        fake_upgraded_acq = MagicMock()
+        fake_upgraded_acq.model_dump.return_value = {
+            "schema_version": "2.5.1",
+        }
+
+        fake_metadata = MagicMock()
+        fake_metadata.acquisition = fake_upgraded_acq
+        fake_metadata.instrument = None
+
+        mock_upgrade_instance = MagicMock()
+        mock_upgrade_instance.metadata = fake_metadata
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_source_dir(tmpdir, acq_data=v1_acq)
+
+            with patch(
+                "aind_metadata_upgrader.upgrade.Upgrade",
+                return_value=mock_upgrade_instance,
+            ) as mock_upgrade_cls:
+                upgrade_metadata(source_dir, "s3://bucket/dataset")
+
+                # Record should not contain 'instrument' key
+                call_args = mock_upgrade_cls.call_args
+                self.assertNotIn("instrument", call_args[0][0])
+
+                # Only backup + upload for acquisition = 2 calls
+                self.assertEqual(mock_cp.call_count, 2)
+
+    @patch(
+        "aind_exaspim_data_transformation.upgrade_metadata"
+        ".utils.copy_file_to_s3"
+    )
+    def test_s3_trailing_slash_handled(self, mock_cp):
+        """S3 location with trailing slash should not produce double slashes."""
+        v1_acq = {"schema_version": "1.0.4", "tiles": []}
+
+        fake_upgraded_acq = MagicMock()
+        fake_upgraded_acq.model_dump.return_value = {
+            "schema_version": "2.5.1",
+        }
+
+        fake_metadata = MagicMock()
+        fake_metadata.acquisition = fake_upgraded_acq
+        fake_metadata.instrument = None
+
+        mock_upgrade_instance = MagicMock()
+        mock_upgrade_instance.metadata = fake_metadata
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_source_dir(tmpdir, acq_data=v1_acq)
+
+            with patch(
+                "aind_metadata_upgrader.upgrade.Upgrade",
+                return_value=mock_upgrade_instance,
+            ):
+                upgrade_metadata(
+                    source_dir, "s3://bucket/dataset/"  # trailing slash
+                )
+
+                for call in mock_cp.call_args_list:
+                    s3_dest = call[0][1]
+                    self.assertNotIn("//", s3_dest.replace("s3://", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_upgrade_metadata.py
+++ b/tests/test_upgrade_metadata.py
@@ -116,18 +116,16 @@ class TestUpgradeMetadata(unittest.TestCase):
 
         return str(source_dir)
 
-    def test_skips_when_no_acquisition(self):
-        """Should log warning and return early when acquisition.json is
+    def test_raises_when_no_acquisition(self):
+        """Should raise FileNotFoundError when acquisition.json is
         missing."""
         with tempfile.TemporaryDirectory() as tmpdir:
             source_dir = self._make_source_dir(tmpdir)
 
-            with patch(
-                "aind_exaspim_data_transformation.upgrade_metadata"
-                ".utils.copy_file_to_s3"
-            ) as mock_cp:
+            with self.assertRaises(FileNotFoundError) as ctx:
                 upgrade_metadata(source_dir, "s3://bucket/dataset")
-                mock_cp.assert_not_called()
+
+            self.assertIn("acquisition.json", str(ctx.exception))
 
     def test_skips_when_already_v2(self):
         """Should skip silently when acquisition is already v2+."""


### PR DESCRIPTION
Metadata Upgrade: v1 → v2.5+
Adds a standalone module to upgrade acquisition.json (and optionally instrument.json) from aind-data-schema v1 to v2.5+, using the aind-metadata-upgrader package.

Changes
upgrade_metadata.py — New module that reads v1 metadata from the local dataset directory, upgrades via aind-metadata-upgrader, backs up originals to s3://.../derived/v1_acquisition.json (and v1_instrument.json), and uploads upgraded files to the S3 dataset root. Silently skips if already v2+. Runnable standalone via python -m aind_exaspim_data_transformation.upgrade_metadata.
test_upgrade_metadata.py — 16 unit tests covering: v1/v2 version detection, missing files, acquisition-only upgrade, both-files upgrade, S3 path handling.
pyproject.toml — Added aind-metadata-upgrader>=0.8.0 dependency.
test_airflow.py — Integrated upgrade_metadata() call before job submission (opt-out via --no-metadata-upgrade).
acquisition.json — Example v1 file for reference/testing.
Key design decisions
Standalone script (not integrated into run_job()) — zero changes to the compression pipeline
Missing instrument.json is non-blocking — proceeds with acquisition-only upgrade
skip_metadata_validation=True since we only have partial metadata (no subject/procedures)
Upgrade failure in test_airflow.py is caught and logged, doesn't block job submission