### PR TITLE
Core runtime fixes are in imaris_job.py: env-aware settings construct…

### DIFF
--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -29,7 +29,7 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-f863be9"
+IMAGE_VERSION = "dev-d042f97"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
 S3_BUCKET_PREFIX = "aind-open-data-dev-u5u0i5"  # actual S3 bucket name for dev

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -1,5 +1,6 @@
 """Module to handle zeiss data compression"""
 
+import json
 import logging
 import multiprocessing
 import os
@@ -564,8 +565,22 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             logging.info(
                 f"Uploading {derivatives_path} to {s3_derivatives_dir}"
             )
-            utils.sync_dir_to_s3(derivatives_path, s3_derivatives_dir)
-            logging.info(f"{derivatives_path} uploaded to s3.")
+            try:
+                utils.sync_dir_to_s3(derivatives_path, s3_derivatives_dir)
+                logging.info(f"{derivatives_path} uploaded to s3.")
+            except (
+                OSError,
+                ValueError,
+                RuntimeError,
+                ClientError,
+                BotoCoreError,
+            ) as exc:
+                logging.error(
+                    "DERIVATIVES UPLOAD FAILED — continuing with "
+                    "compression. Error: %s",
+                    exc,
+                    exc_info=True,
+                )
 
     def _build_global_shard_task_list(
         self, stack_paths: List[Path]
@@ -756,8 +771,16 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
         job_start_time = time()
 
         # Worker 0 handles one-time setup: metadata upgrade + derivatives
-        logging.info(f'Running partition {self.job_settings.partition_to_process} '
-                     f'of {self.job_settings.num_of_partitions}')
+        logging.info(
+            "Running partition %s of %s",
+            self.job_settings.partition_to_process,
+            self.job_settings.num_of_partitions,
+        )
+        logging.info(
+            "partition_to_process type=%s value=%r",
+            type(self.job_settings.partition_to_process).__name__,
+            self.job_settings.partition_to_process,
+        )
         if self.job_settings.partition_to_process == 0:
             self._upgrade_metadata()
             self._upload_derivatives_folder()
@@ -795,11 +818,12 @@ def job_entrypoint(sys_args: list):
     parser = get_parser()
     cli_args = parser.parse_args(sys_args)
     if cli_args.job_settings is not None:
-        job_settings = ImarisJobSettings.model_validate_json(
-            cli_args.job_settings
-        )
+        job_settings_json = json.loads(cli_args.job_settings)
+        job_settings = ImarisJobSettings(**job_settings_json)
     elif cli_args.config_file is not None:
-        job_settings = ImarisJobSettings.from_config_file(cli_args.config_file)
+        with open(cli_args.config_file, "r", encoding="utf-8") as f:
+            file_contents = json.load(f)
+        job_settings = ImarisJobSettings(**file_contents)
     else:
         # Construct settings from env vars or defaults (backwards compatible)
         job_settings = ImarisJobSettings()  # type: ignore[call-arg]

--- a/tests/test_imaris_job.py
+++ b/tests/test_imaris_job.py
@@ -1,5 +1,6 @@
 """Tests for ImarisCompressionJob class"""
 
+import os
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
@@ -1134,7 +1135,7 @@ class TestJobEntrypoint(unittest.TestCase):
         mock_get_parser.return_value = mock_parser
 
         mock_settings = MagicMock()
-        mock_settings_cls.model_validate_json.return_value = mock_settings
+        mock_settings_cls.return_value = mock_settings
 
         mock_job = MagicMock()
         mock_job.run_job.return_value = MagicMock(
@@ -1145,15 +1146,28 @@ class TestJobEntrypoint(unittest.TestCase):
         job_entrypoint(["--job-settings", "{}"])
 
         mock_mp.set_start_method.assert_called_once_with("spawn", force=True)
-        mock_settings_cls.model_validate_json.assert_called_once()
+        mock_settings_cls.assert_called_once_with(
+            input_source="/input",
+            output_directory="/output",
+            num_of_partitions=1,
+            partition_to_process=0,
+        )
         mock_job.run_job.assert_called_once()
 
     @patch("aind_exaspim_data_transformation.imaris_job.ImarisCompressionJob")
+    @patch("aind_exaspim_data_transformation.imaris_job.json.load")
+    @patch("builtins.open")
     @patch("aind_exaspim_data_transformation.imaris_job.ImarisJobSettings")
     @patch("aind_exaspim_data_transformation.imaris_job.get_parser")
     @patch("aind_exaspim_data_transformation.imaris_job.multiprocessing")
     def test_job_entrypoint_with_config_file(
-        self, mock_mp, mock_get_parser, mock_settings_cls, mock_job_cls
+        self,
+        mock_mp,
+        mock_get_parser,
+        mock_settings_cls,
+        mock_open,
+        mock_json_load,
+        mock_job_cls,
     ):
         """Test job_entrypoint with --config-file argument"""
         from aind_exaspim_data_transformation.imaris_job import job_entrypoint
@@ -1164,9 +1178,15 @@ class TestJobEntrypoint(unittest.TestCase):
         mock_args.config_file = "/path/to/config.json"
         mock_parser.parse_args.return_value = mock_args
         mock_get_parser.return_value = mock_parser
+        mock_json_load.return_value = {
+            "input_source": "/input",
+            "output_directory": "/output",
+            "num_of_partitions": 1,
+            "partition_to_process": 0,
+        }
 
         mock_settings = MagicMock()
-        mock_settings_cls.from_config_file.return_value = mock_settings
+        mock_settings_cls.return_value = mock_settings
 
         mock_job = MagicMock()
         mock_job.run_job.return_value = MagicMock(
@@ -1176,8 +1196,14 @@ class TestJobEntrypoint(unittest.TestCase):
 
         job_entrypoint([])
 
-        mock_settings_cls.from_config_file.assert_called_once_with(
-            "/path/to/config.json"
+        mock_open.assert_called_once_with(
+            "/path/to/config.json", "r", encoding="utf-8"
+        )
+        mock_settings_cls.assert_called_once_with(
+            input_source="/input",
+            output_directory="/output",
+            num_of_partitions=1,
+            partition_to_process=0,
         )
 
     @patch("aind_exaspim_data_transformation.imaris_job.ImarisCompressionJob")
@@ -1210,6 +1236,42 @@ class TestJobEntrypoint(unittest.TestCase):
 
         # Settings created from env vars (no arguments)
         mock_settings_cls.assert_called_once_with()
+
+    @patch("aind_exaspim_data_transformation.imaris_job.ImarisCompressionJob")
+    @patch("aind_exaspim_data_transformation.imaris_job.get_parser")
+    @patch("aind_exaspim_data_transformation.imaris_job.multiprocessing")
+    def test_job_entrypoint_job_settings_merges_partition_from_env(
+        self, mock_mp, mock_get_parser, mock_job_cls
+    ):
+        """Test env var partition is merged when missing from JSON settings."""
+        from aind_exaspim_data_transformation.imaris_job import job_entrypoint
+
+        mock_parser = MagicMock()
+        mock_args = MagicMock()
+        mock_args.job_settings = (
+            '{"input_source": "/input", "output_directory": "/output", '
+            '"num_of_partitions": 64}'
+        )
+        mock_args.config_file = None
+        mock_parser.parse_args.return_value = mock_args
+        mock_get_parser.return_value = mock_parser
+
+        mock_job = MagicMock()
+        mock_job.run_job.return_value = MagicMock(
+            model_dump_json=lambda: '{"status": 200}'
+        )
+        mock_job_cls.return_value = mock_job
+
+        with patch.dict(
+            os.environ,
+            {"TRANSFORMATION_JOB_PARTITION_TO_PROCESS": "0"},
+            clear=False,
+        ):
+            job_entrypoint(["--job-settings", "{}"])
+
+        self.assertTrue(mock_job_cls.called)
+        job_settings = mock_job_cls.call_args.kwargs["job_settings"]
+        self.assertEqual(job_settings.partition_to_process, 0)
 
 
 class TestGetTileTranslationFromAcquisition(unittest.TestCase):


### PR DESCRIPTION
…ion, safer derivatives upload handling, and partition type/value diagnostics before the worker-0 gate.

Airflow example env export was updated in test_airflow.py to use the Apptainer prefix for partition propagation. Entrypoint regression coverage was added/updated in test_imaris_job.py, including env merge behavior for partition 0.