### PR TITLE
Fix metadata 4

### DIFF
--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -29,7 +29,7 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-e631a30"
+IMAGE_VERSION = "dev-a06e72c"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
 S3_BUCKET_PREFIX = "aind-open-data-dev-u5u0i5"  # actual S3 bucket name for dev

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -511,11 +511,38 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
                     bucket_name=bucket_name,
                 )
 
+    @staticmethod
+    def _get_dataset_root_s3(s3_location: str) -> str:
+        """Strip the modality subfolder from an S3 location URI.
+
+        The pipeline passes ``s3_location`` as
+        ``s3://{bucket}/{dataset_name}/{modality}`` (e.g. ``…/SPIM``).
+        Metadata files must be written to the dataset root, one level up.
+
+        Parameters
+        ----------
+        s3_location : str
+            Full S3 URI that may include a trailing modality segment.
+
+        Returns
+        -------
+        str
+            S3 URI pointing to the dataset root (modality segment removed).
+        """
+        parsed = urlparse(s3_location)
+        dataset_root_path = str(Path(parsed.path.rstrip("/")).parent)
+        return f"s3://{parsed.netloc}{dataset_root_path}"
+
     def _upgrade_metadata(self):
         """Upgrade v1 metadata files and upload to S3.
 
         Only runs when ``s3_location`` is configured.  Errors are logged
         but do **not** abort the compression pipeline.
+
+        The pipeline provides ``s3_location`` with a modality subfolder
+        (e.g. ``s3://bucket/dataset/SPIM``).  Metadata files belong at
+        the dataset root, so the modality segment is stripped before
+        calling :func:`upgrade_metadata`.
         """
         if self.job_settings.s3_location is None:
             logging.info(
@@ -523,16 +550,23 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             )
             return
 
+        # s3_location includes the modality subfolder (e.g. .../SPIM).
+        # Metadata files must go to the dataset root (one level up).
+        s3_dataset_root = self._get_dataset_root_s3(
+            self.job_settings.s3_location
+        )
+
         logging.info(
             "Starting metadata upgrade for source_dir=%s, "
-            "s3_location=%s",
+            "s3_location=%s (dataset root: %s)",
             self.job_settings.input_source,
             self.job_settings.s3_location,
+            s3_dataset_root,
         )
         try:
             upgrade_metadata(
                 source_dir=str(self.job_settings.input_source),
-                s3_location=self.job_settings.s3_location,
+                s3_location=s3_dataset_root,
                 dry_run=False,
             )
             logging.info("Metadata upgrade completed successfully.")

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -102,33 +102,9 @@ def _upload_upgraded_to_s3(
     _upload_bytes_to_s3(body, s3_dest)
 
 
-def _is_instrument_required_error(exc: ValueError) -> bool:
+def _is_instrument_required_error(exc: BaseException) -> bool:
     """Return True when *exc* indicates instrument metadata is required."""
     return "Instrument metadata is required" in str(exc)
-
-
-def _upload_original_acquisition_fallback(
-    acq_path: Path,
-    acq_data: dict,
-    s3_location: str,
-    dry_run: bool,
-) -> None:
-    """Backup and upload original acquisition.json when upgrade cannot proceed."""
-    if dry_run:
-        logger.info(
-            "[DRY RUN] Would back up %s → %s/derived/v1_acquisition.json",
-            acq_path,
-            s3_location.rstrip("/"),
-        )
-        logger.info(
-            "[DRY RUN] Would upload original acquisition.json "
-            "(schema_version %s) → %s/acquisition.json",
-            acq_data.get("schema_version"),
-            s3_location.rstrip("/"),
-        )
-    else:
-        _backup_original_to_s3(acq_path, s3_location, "acquisition.json")
-        _upload_upgraded_to_s3(acq_data, s3_location, "acquisition.json")
 
 
 def _to_json_dict(data: Any) -> dict | None:
@@ -273,23 +249,25 @@ def upgrade_metadata(
 
     try:
         upgraded = Upgrade(record, skip_metadata_validation=True)
-    except ValueError as exc:
-        if inst_data is None and _is_instrument_required_error(exc):
+    except (ValueError, KeyError, AttributeError) as exc:
+        if _is_instrument_required_error(exc):
             logger.warning(
-                "instrument.json is missing and upgrader requires it; "
-                "falling back to uploading original acquisition.json "
-                "without schema upgrade. Error: %s",
+                "\n"
+                "========================================================\n"
+                "  WARNING: METADATA UPGRADE SKIPPED                     \n"
+                "========================================================\n"
+                "  instrument.json is missing and the upgrader requires  \n"
+                "  it to convert tiles → data_streams.                   \n"
+                "                                                        \n"
+                "  acquisition.json was NOT uploaded to S3.              \n"
+                "  No stale v1 metadata has been written.                \n"
+                "                                                        \n"
+                "  To fix: place a valid instrument.json next to         \n"
+                "  acquisition.json in the dataset directory and re-run. \n"
+                "========================================================\n"
+                "  Error: %s\n"
+                "========================================================",
                 exc,
-            )
-            _upload_original_acquisition_fallback(
-                acq_path=acq_path,
-                acq_data=acq_data,
-                s3_location=s3_location,
-                dry_run=dry_run,
-            )
-            logger.info(
-                "Uploaded original acquisition.json without upgrade "
-                "because instrument metadata was unavailable."
             )
             return
         raise

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -250,22 +250,20 @@ def upgrade_metadata(
     try:
         upgraded = Upgrade(record, skip_metadata_validation=True)
     except (ValueError, KeyError, AttributeError) as exc:
-        if _is_instrument_required_error(exc):
+        if inst_data is None and _is_instrument_required_error(exc):
             logger.warning(
                 "\n"
                 "========================================================\n"
-                "  WARNING: METADATA UPGRADE SKIPPED                     \n"
+                "  WARNING: instrument.json NOT FOUND                    \n"
                 "========================================================\n"
-                "  instrument.json is missing and the upgrader requires  \n"
-                "  it to convert tiles → data_streams.                   \n"
-                "                                                        \n"
-                "  acquisition.json was NOT uploaded to S3.              \n"
-                "  No stale v1 metadata has been written.                \n"
+                "  The upgrader requires instrument metadata to convert  \n"
+                "  tiles → data_streams.  Without instrument.json the   \n"
+                "  acquisition cannot be upgraded to v2.                 \n"
                 "                                                        \n"
                 "  To fix: place a valid instrument.json next to         \n"
                 "  acquisition.json in the dataset directory and re-run. \n"
                 "========================================================\n"
-                "  Error: %s\n"
+                "  Original error: %s\n"
                 "========================================================",
                 exc,
             )

--- a/tests/test_imaris_job.py
+++ b/tests/test_imaris_job.py
@@ -919,13 +919,34 @@ class TestImarisCompressionJob(unittest.TestCase):
 
     @patch("aind_exaspim_data_transformation.imaris_job.upgrade_metadata")
     def test_upgrade_metadata_called_with_s3_location(self, mock_upgrade):
-        """_upgrade_metadata calls upgrade_metadata when s3_location is set"""
+        """_upgrade_metadata strips modality suffix from s3_location"""
         settings = ImarisJobSettings(
             input_source="/fake/input",
             output_directory="/fake/output",
             num_of_partitions=1,
             partition_to_process=0,
+            s3_location="s3://bucket/dataset/SPIM",
+        )
+        job = ImarisCompressionJob(job_settings=settings)
+        job._upgrade_metadata()
+
+        mock_upgrade.assert_called_once_with(
+            source_dir="/fake/input",
             s3_location="s3://bucket/dataset",
+            dry_run=False,
+        )
+
+    @patch("aind_exaspim_data_transformation.imaris_job.upgrade_metadata")
+    def test_upgrade_metadata_strips_trailing_modality_slash(
+        self, mock_upgrade
+    ):
+        """_upgrade_metadata handles trailing slash on modality suffix"""
+        settings = ImarisJobSettings(
+            input_source="/fake/input",
+            output_directory="/fake/output",
+            num_of_partitions=1,
+            partition_to_process=0,
+            s3_location="s3://bucket/dataset/SPIM/",
         )
         job = ImarisCompressionJob(job_settings=settings)
         job._upgrade_metadata()

--- a/tests/test_upgrade_metadata.py
+++ b/tests/test_upgrade_metadata.py
@@ -286,15 +286,28 @@ class TestUpgradeMetadata(unittest.TestCase):
         "aind_exaspim_data_transformation.upgrade_metadata"
         "._upload_bytes_to_s3"
     )
-    def test_warns_and_skips_when_upgrader_requires_instrument(
+    def test_warns_and_skips_when_instrument_missing(
         self, mock_upload
     ):
-        """Missing instrument logs a loud warning and skips upload.
+        """Missing instrument causes a warning and graceful return.
 
-        No exception should propagate and no S3 uploads should occur —
-        the function returns cleanly after logging.
+        When the upgrader raises ValueError because instrument metadata
+        is required and no instrument.json exists on disk, the function
+        should log a loud warning and return without uploading anything.
         """
-        v1_acq = {"schema_version": "1.0.4", "tiles": [], "axes": []}
+        v1_acq = {
+            "schema_version": "1.0.4",
+            "tiles": [
+                {
+                    "channel": {
+                        "channel_name": "488",
+                        "light_source_name": "488 nm",
+                        "excitation_wavelength": 488,
+                    }
+                }
+            ],
+            "axes": [],
+        }
 
         with tempfile.TemporaryDirectory() as tmpdir:
             source_dir = self._make_source_dir(tmpdir, acq_data=v1_acq)
@@ -302,13 +315,17 @@ class TestUpgradeMetadata(unittest.TestCase):
             with patch(
                 "aind_metadata_upgrader.upgrade.Upgrade",
                 side_effect=ValueError(
-                    "Instrument metadata is required to upgrade tiles to data streams"
+                    "Instrument metadata is required to upgrade "
+                    "tiles to data streams"
                 ),
-            ):
-                # Should NOT raise — returns cleanly after warning
+            ) as mock_upgrade_cls:
+                # Should NOT raise — returns gracefully
                 upgrade_metadata(source_dir, "s3://bucket/dataset")
 
-                # No S3 uploads should have occurred
+                # Upgrade was attempted once
+                self.assertEqual(mock_upgrade_cls.call_count, 1)
+
+                # Nothing should be uploaded
                 mock_upload.assert_not_called()
 
     @patch(

--- a/tests/test_upgrade_metadata.py
+++ b/tests/test_upgrade_metadata.py
@@ -286,8 +286,14 @@ class TestUpgradeMetadata(unittest.TestCase):
         "aind_exaspim_data_transformation.upgrade_metadata"
         "._upload_bytes_to_s3"
     )
-    def test_fallback_when_upgrader_requires_instrument(self, mock_upload):
-        """Fallback uploads original acquisition when instrument is required."""
+    def test_warns_and_skips_when_upgrader_requires_instrument(
+        self, mock_upload
+    ):
+        """Missing instrument logs a loud warning and skips upload.
+
+        No exception should propagate and no S3 uploads should occur —
+        the function returns cleanly after logging.
+        """
         v1_acq = {"schema_version": "1.0.4", "tiles": [], "axes": []}
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -299,19 +305,11 @@ class TestUpgradeMetadata(unittest.TestCase):
                     "Instrument metadata is required to upgrade tiles to data streams"
                 ),
             ):
+                # Should NOT raise — returns cleanly after warning
                 upgrade_metadata(source_dir, "s3://bucket/dataset")
 
-                # backup v1 acq + upload original acq to root
-                self.assertEqual(mock_upload.call_count, 2)
-
-                backup_call = mock_upload.call_args_list[0]
-                self.assertIn(
-                    "derived/v1_acquisition.json", backup_call[0][1]
-                )
-
-                upload_call = mock_upload.call_args_list[1]
-                self.assertIn("acquisition.json", upload_call[0][1])
-                self.assertNotIn("derived", upload_call[0][1])
+                # No S3 uploads should have occurred
+                mock_upload.assert_not_called()
 
     @patch(
         "aind_exaspim_data_transformation.upgrade_metadata"
@@ -347,6 +345,203 @@ class TestUpgradeMetadata(unittest.TestCase):
                 for call in mock_upload.call_args_list:
                     s3_dest = call[0][1]
                     self.assertNotIn("//", s3_dest.replace("s3://", ""))
+
+
+    @patch(
+        "aind_exaspim_data_transformation.upgrade_metadata"
+        "._upload_bytes_to_s3"
+    )
+    def test_upgraded_version_is_v2_or_higher(self, mock_upload):
+        """Uploaded acquisition.json must have schema_version >= 2.0.0."""
+        v1_acq = {"schema_version": "1.0.4", "tiles": [], "axes": []}
+
+        fake_upgraded_acq = MagicMock()
+        fake_upgraded_acq.model_dump.return_value = {
+            "schema_version": "2.5.1",
+            "data_streams": [],
+        }
+
+        fake_metadata = MagicMock()
+        fake_metadata.acquisition = fake_upgraded_acq
+        fake_metadata.instrument = None
+
+        mock_upgrade_instance = MagicMock()
+        mock_upgrade_instance.metadata = fake_metadata
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_source_dir(tmpdir, acq_data=v1_acq)
+
+            with patch(
+                "aind_metadata_upgrader.upgrade.Upgrade",
+                return_value=mock_upgrade_instance,
+            ):
+                upgrade_metadata(source_dir, "s3://bucket/dataset")
+
+                # Find the non-backup upload call (the upgraded acquisition)
+                for call in mock_upload.call_args_list:
+                    s3_dest = call[0][1]
+                    if "derived" in s3_dest:
+                        continue
+                    # This is the upgraded file — parse the JSON body
+                    body = call[0][0]
+                    uploaded = json.loads(body.decode("utf-8"))
+                    from packaging.version import parse as vparse
+
+                    self.assertGreaterEqual(
+                        vparse(uploaded["schema_version"]),
+                        vparse("2.0.0"),
+                        f"Uploaded acquisition.json has "
+                        f"schema_version={uploaded['schema_version']} "
+                        f"which is below 2.0.0",
+                    )
+
+
+class TestUpgradeMetadataRealUpgrader(unittest.TestCase):
+    """Integration test using the real aind-metadata-upgrader (no mocks).
+
+    Uses ``docs/examples/acquisition.json`` from this repository with a
+    minimal ``instrument.json`` stub so the upgrader can run end-to-end.
+    Runs with ``dry_run=True`` so no S3 credentials are needed.
+    """
+
+    EXAMPLE_ACQ = Path(__file__).resolve().parent.parent / (
+        "docs/examples/acquisition.json"
+    )
+
+    def _make_dataset(self, tmpdir):
+        """Copy the example acquisition.json and create a minimal instrument
+        stub into a temporary dataset directory.  Returns the source_dir."""
+        dataset_dir = Path(tmpdir) / "exaSPIM_test_2026-01-01_00-00-00"
+        source_dir = dataset_dir / "exaSPIM"
+        source_dir.mkdir(parents=True)
+
+        # Copy the real v1 acquisition.json (use copy, not copy2,
+        # to avoid preserving restrictive source file permissions)
+        import shutil
+
+        shutil.copy(self.EXAMPLE_ACQ, dataset_dir / "acquisition.json")
+
+        # Create a minimal instrument.json to satisfy the upgrader.
+        # Based on the real v1 fixture from aind-metadata-upgrader tests.
+        instrument_stub = {
+            "schema_version": "0.10.20",
+            "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
+            "instrument_id": "exaSPIM",
+            "instrument_type": "exaSPIM",
+            "manufacturer": {"name": "Other"},
+            "objectives": [
+                {
+                    "device_type": "Objective",
+                    "name": "Custom Objective",
+                    "serial_number": None,
+                    "manufacturer": {"name": "Other"},
+                    "model": "JM_DIAMOND 5.0X/1.3",
+                    "numerical_aperture": "0.305",
+                    "magnification": "5",
+                    "immersion": "air",
+                    "notes": None,
+                }
+            ],
+            "detectors": [
+                {
+                    "device_type": "Detector",
+                    "name": "Camera 1",
+                    "serial_number": None,
+                    "manufacturer": {"name": "Vieworks"},
+                    "detector_type": "Camera",
+                    "data_interface": "Coax",
+                    "cooling": "Air",
+                    "notes": None,
+                }
+            ],
+            "light_sources": [
+                {
+                    "device_type": "Laser",
+                    "name": "LAS-001",
+                    "serial_number": None,
+                    "manufacturer": {"name": "Oxxius"},
+                    "wavelength": 488,
+                    "wavelength_unit": "nanometer",
+                    "coupling": "Single-mode fiber",
+                    "notes": None,
+                }
+            ],
+            "fluorescence_filters": [],
+            "lenses": [],
+            "scanning_stages": [
+                {
+                    "device_type": "Motorized stage",
+                    "name": "stage-x",
+                    "serial_number": None,
+                    "manufacturer": {
+                        "name": "Applied Scientific Instrumentation",
+                        "abbreviation": "ASI",
+                    },
+                    "model": "MS-8000",
+                    "travel": "1000",
+                    "travel_unit": "millimeter",
+                    "stage_axis_direction": "Detection axis",
+                    "stage_axis_name": "X",
+                    "notes": None,
+                }
+            ],
+            "motorized_stages": [],
+            "additional_devices": [],
+            "com_ports": [],
+            "daqs": [],
+            "calibration_date": None,
+            "calibration_data": None,
+            "notes": None,
+        }
+        (dataset_dir / "instrument.json").write_text(
+            json.dumps(instrument_stub, indent=2)
+        )
+
+        return str(source_dir)
+
+    @patch(
+        "aind_exaspim_data_transformation.upgrade_metadata"
+        "._upload_bytes_to_s3"
+    )
+    def test_real_upgrade_produces_v2(self, mock_upload):
+        """The real upgrader must produce schema_version >= 2.0.0.
+
+        This test uses the actual ``aind_metadata_upgrader.upgrade.Upgrade``
+        class (no mocks) and validates the version of the JSON that would
+        be uploaded to S3.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_dir = self._make_dataset(tmpdir)
+
+            upgrade_metadata(
+                source_dir, "s3://test-bucket/test-dataset", dry_run=False
+            )
+
+            # At least one non-backup upload should have occurred
+            non_backup_uploads = [
+                call
+                for call in mock_upload.call_args_list
+                if "derived" not in call[0][1]
+            ]
+            self.assertGreater(
+                len(non_backup_uploads),
+                0,
+                "Expected at least one non-backup upload",
+            )
+
+            for call in non_backup_uploads:
+                s3_dest = call[0][1]
+                body = call[0][0]
+                uploaded = json.loads(body.decode("utf-8"))
+                from packaging.version import parse as vparse
+
+                self.assertGreaterEqual(
+                    vparse(uploaded.get("schema_version", "0.0.0")),
+                    vparse("2.0.0"),
+                    f"Uploaded {s3_dest} has "
+                    f"schema_version={uploaded.get('schema_version')} "
+                    f"which is below 2.0.0",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removed _build_synthetic_instrument() (the entire ~90-line function)
Removed the retry-with-synthetic-stub logic from the except block
Removed the used_synthetic_instrument flag
The except block now logs a loud warning banner and returns gracefully (no upload, no crash) when the upgrader fails due to missing instrument.json
test_upgrade_metadata.py:

Replaced test_retries_with_synthetic_instrument_when_missing → test_warns_and_skips_when_instrument_missing (asserts single Upgrade attempt, zero uploads)
Removed test_real_upgrade_without_instrument_produces_v2 integration test