### PR TITLE
Feat fix exaspim airflow

### DIFF
--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -15,6 +15,7 @@ import os
 import re
 from datetime import datetime
 from glob import glob
+import json
 
 import requests
 from aind_data_schema_models.modalities import Modality
@@ -29,20 +30,11 @@ from aind_data_transfer_service.models.core import (
 
 # ── Configurable defaults ──────────────────────────────────────────
 IMAGE = "ghcr.io/allenneuraldynamics/aind-exaspim-data-transformation"
-IMAGE_VERSION = "dev-1b07bee"
+IMAGE_VERSION = "dev-a867744"
 ENDPOINT = "http://aind-data-transfer-service-dev"
 S3_BUCKET = "open"  # maps to aind-open-data-dev
-S3_BUCKET_PREFIX = "aind-open-data-dev-u5u0i5"  # actual S3 bucket name for dev
-JOB_TYPE = "default"  # registered job type on the dev cluster
-
-# Resource limits
+JOB_TYPE = "exaSPIM"  # registered job type on the dev cluster
 MAX_PARTITIONS = 64
-CPUS_PER_NODE = 4
-MIN_RAM_MB = 24_000
-MAX_RAM_MB = 40_000
-SCHEDULING_OVERHEAD_MB = 1_300  # per tile, from profiling
-PROCESSING_OVERHEAD_MB = 4_400  # per shard, from profiling
-BUFFER_MB = 1_000
 PROCESSING_SPEED_MB_PER_HOUR = 12_200
 # ────────────────────────────────────────────────────────────────────
 
@@ -56,38 +48,15 @@ def _discover_ims_files(source: str) -> list[str]:
 
 
 def _first_file_size_mb(ims_files: list[str]) -> float:
-    """Size of the first .ims file in MB (used for resource estimation)."""
+    """Size of the first .ims file in MB (used for timeout estimation)."""
     return os.path.getsize(ims_files[0]) / (1024 * 1024)
 
 
-def _estimate_resources(
-    n_tiles: int, tile_size_mb: float
-) -> tuple[int, int, int]:
-    """Return (num_partitions, memory_per_cpu_mb, timeout_minutes)."""
-    # num_partitions = min(n_tiles, MAX_PARTITIONS)
-    # tiles_per_partition = max(n_tiles // num_partitions, 1)
-    # we want to run multiple partitions per file
-    num_partitions = MAX_PARTITIONS
-
-    # estimated_mem = (
-    #     tiles_per_partition * SCHEDULING_OVERHEAD_MB
-    #     + PROCESSING_OVERHEAD_MB
-    #     + BUFFER_MB
-    # ) // CPUS_PER_NODE
-    estimated_mem = (
-        MIN_RAM_MB // CPUS_PER_NODE
-    )  # from profiling, seems to need at least this much per CPU regardless of tile size
-
-    memory_per_cpu = min(
-        max(estimated_mem, MIN_RAM_MB // CPUS_PER_NODE),
-        MAX_RAM_MB // CPUS_PER_NODE,
-    )
-
-    timeout_min = int(
+def _estimate_timeout(n_tiles: int, tile_size_mb: float) -> int:
+    """Return estimated timeout in minutes based on data volume."""
+    return int(
         (n_tiles * tile_size_mb / 1024) / PROCESSING_SPEED_MB_PER_HOUR + 60
     )
-
-    return num_partitions, memory_per_cpu, timeout_min
 
 
 def _parse_acq_datetime(path: str) -> datetime:
@@ -115,6 +84,46 @@ def _derive_subject_id(path: str) -> str:
             else basename.split("_")[0]
         )
     return basename
+
+def get_additional_metadata(subject_id: str, data_directory: str): 
+    labtracks_id = subject_id.split("-")[0]
+
+    # Download subject and procedures from metadata service
+    metadata_service_url = "http://aind-metadata-service/"  # for prod
+    # metadata_service_url = "http://aind-metadata-service-dev"  # for testing
+    metadata_files = [os.path.basename(x) for x in glob(f"{data_directory}/*.json")]
+
+    # Create empty subject.json if metadata service fails or for testing
+    if "subject.json" not in metadata_files:
+        try:
+            subject_response = requests.get(
+                f"{metadata_service_url}/api/v2/subject/{labtracks_id}"
+            )
+            if subject_response.status_code in [200, 400]:
+                json_data = subject_response.json()
+                with open(f"{data_directory}/subject.json", "w") as f:
+                    json.dump(json_data, f, indent=3)
+            else:
+                subject_response.raise_for_status()
+        except Exception as e:
+            print(f"Failed to get subject from metadata service: {e}")
+            print("Creating empty subject.json file...")
+
+    # Create empty procedures.json if metadata service fails or for testing
+    if "procedures.json" not in metadata_files:
+        try:
+            procedures_response = requests.get(
+                f"{metadata_service_url}/api/v2/procedures/{labtracks_id}"
+            )
+            if procedures_response.status_code in [200, 400]:
+                json_data = procedures_response.json()
+                with open(f"{data_directory}/procedures.json", "w") as f:
+                    json.dump(json_data, f, indent=3)
+            else:
+                procedures_response.raise_for_status()
+        except Exception as e:
+            print(f"Failed to get procedures from metadata service: {e}")
+            print("Creating empty procedures.json file...")
 
 
 def submit_exaspim_job(
@@ -146,64 +155,42 @@ def submit_exaspim_job(
     if subject_id is None:
         subject_id = _derive_subject_id(source)
 
+    # Fetch subject.json and procedures.json from the metadata service
+    # into the dataset root (one level up from the exaSPIM/ source dir).
+    # data_directory = os.path.dirname(os.path.normpath(source))
+    # get_additional_metadata(subject_id, data_directory)
+
     acq_datetime = _parse_acq_datetime(source)
     ims_files = _discover_ims_files(source)
     n_tiles = len(ims_files)
     tile_size_mb = _first_file_size_mb(ims_files)
-    num_partitions, mem_mb, timeout_min = _estimate_resources(
-        n_tiles, tile_size_mb
-    )
+    num_partitions = MAX_PARTITIONS
+    timeout_min = _estimate_timeout(n_tiles, tile_size_mb)
 
     print(f"Tiles found       : {n_tiles}")
     print(f"First tile size   : {tile_size_mb:,.0f} MB")
     print(f"Partitions        : {num_partitions}")
-    print(f"Memory / CPU      : {mem_mb:,} MB")
     print(f"Timeout           : {timeout_min} min")
     if single_tile_upload:
         print(f"Single tile mode  : ENABLED (testing first tile only)")
 
+    # Only per-job overrides; image, resources, command_script, and most
+    # job_settings are provided by the "exaSPIM" job type on the server.
     exaspim_job_settings = {
         "input_source": source,
-        "output_directory": "%OUTPUT_LOCATION",
-        "s3_location": "%S3_LOCATION",
         "num_of_partitions": num_partitions,
-        "use_tensorstore": True,
-        "translate_imaris_pyramid": True,
-        "partition_mode": "shard",
-        "dask_workers": CPUS_PER_NODE,  # use all CPUs for distributed processing
+        "dask_workers": 4,
         "single_tile_upload": single_tile_upload,
     }
 
     custom_exaspim_task = Task(
-        skip_task=False,
         image=IMAGE,
         image_version=IMAGE_VERSION,
         image_resources={
-            "partition": "aind",
-            "qos": "dev",
             "array": f"0-{num_partitions - 1}",
             "time_limit": {"set": True, "number": timeout_min},
-            "memory_per_cpu": {"set": True, "number": mem_mb},
-            "minimum_cpus_per_node": CPUS_PER_NODE,
-            "standard_error": "/allen/aind/scratch/svc_aind_airflow/dev/logs/%x_%j_error.out",
-            "tasks": 1,
-            "standard_output": "/allen/aind/scratch/svc_aind_airflow/dev/logs/%x_%j.out",
-            "environment": [
-                "PATH=/bin:/usr/bin/:/usr/local/bin/",
-                "LD_LIBRARY_PATH=/lib/:/lib64/:/usr/local/lib",
-            ],
-            "maximum_nodes": 1,
-            "minimum_nodes": 1,
-            "current_working_directory": ".",
-            "comment": "retry 2",
         },
         job_settings=exaspim_job_settings,
-        command_script=(
-            "#!/bin/bash \nexport "
-            "SINGULARITYENV_TRANSFORMATION_JOB_PARTITION_TO_PROCESS=$SLURM_ARRAY_TASK_ID"
-            " \nsingularity exec --cleanenv --env-file %ENV_FILE docker://%IMAGE:%IMAGE_VERSION "
-            "python -m aind_exaspim_data_transformation.imaris_job --job-settings ' %JOB_SETTINGS '"
-        ),
     )
 
     upload_job = UploadJobConfigsV2(
@@ -223,7 +210,7 @@ def submit_exaspim_job(
             "check_s3_folder_exists": {"skip_task": True},
             "final_check_s3_folder_exist": {"skip_task": True},
             "check_metadata_files": {"skip_task": True},
-            "gather_preliminary_metadata": {"skip_task": True},
+            "gather_preliminary_metadata": {"skip_task": False},
             "register_data_asset": {"skip_task": True},
             "get_codeocean_asset_id": {"skip_task": True},
             "run_codeocean_pipeline": {"skip_task": True},
@@ -245,13 +232,13 @@ def submit_exaspim_job(
 
 def test_submit_exaspim_job():
     # dataset_name = "exaSPIM_718162_2026-01-29_19-28-50"
-    dataset_name = "exaSPIM_819682-screen_2026-03-11_14-42-37"
+    dataset_name = "exaSPIM_765830_2025-11-21_12-01-47"
     data_dir = f"/allen/aind/stage/exaSPIM/{dataset_name}/exaSPIM"
 
     submit_exaspim_job(
         source=data_dir,
         project_name="MSMA Platform",
-        subject_id="819682-screen",
+        subject_id="765830",
         single_tile_upload=False,  # Set to True for testing with a single tile
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "tensorstore==0.1.80",
     "psutil==7.2.2", 
     "boto3==1.42.36",
-    "aind-metadata-upgrader==0.11.4"
+    "aind-metadata-upgrader>=0.13.4"
 ]
 
 [tool.setuptools]

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -113,6 +113,221 @@ def _to_json_dict(data: Any) -> dict | None:
     return data
 
 
+def _sanitize_instrument_manufacturers(inst_data: dict) -> dict:
+    """Replace unrecognised manufacturer names with ``"Other"``.
+
+    ``aind-metadata-upgrader``'s ``repair_manufacturer()`` calls
+    ``Organization.from_name()`` and assumes the result is non-None.
+    When a manufacturer name (e.g. ``"PhotonGear"``) is not in the
+    ``aind-data-schema-models`` registry the upgrader crashes with
+    ``AttributeError: 'NoneType' object has no attribute 'model_dump'``.
+
+    This pre-processing step walks every device collection that
+    contains a ``manufacturer`` dict and replaces unrecognised names
+    with ``"Other"``, preserving the original name in the ``notes``
+    field so no information is lost.
+    """
+    from aind_data_schema_models.organizations import Organization
+
+    # All top-level device-list keys in a v1 instrument.json that
+    # carry a ``manufacturer`` field.
+    _DEVICE_LISTS = (
+        "objectives",
+        "detectors",
+        "light_sources",
+        "fluorescence_filters",
+        "lenses",
+        "scanning_stages",
+        "motorized_stages",
+        "additional_devices",
+        "daqs",
+        "optical_tables",
+    )
+
+    inst = json.loads(json.dumps(inst_data))  # deep copy
+
+    for key in _DEVICE_LISTS:
+        for device in inst.get(key) or []:
+            mfr = device.get("manufacturer")
+            if not isinstance(mfr, dict):
+                continue
+            name = mfr.get("name", "")
+            if name and Organization.from_name(name) is None:
+                logger.warning(
+                    "Manufacturer %r not recognised by "
+                    "aind-data-schema-models — replacing with 'Other' "
+                    "in %s[%s]",
+                    name,
+                    key,
+                    device.get("name", "?"),
+                )
+                original_note = (
+                    f"(v1v2 pre-process): original manufacturer was "
+                    f"'{name}'"
+                )
+                existing_notes = device.get("notes") or ""
+                device["notes"] = (
+                    f"{existing_notes} {original_note}".strip()
+                    if existing_notes
+                    else original_note
+                )
+                mfr["name"] = "Other"
+
+    # ── Back-fill missing required fields on objectives ─────────────
+    # The v2 Objective model requires ``magnification``.  Some v1
+    # instrument files omit it for non-imaging objectives (e.g.
+    # excitation objectives).  The upgrader's ``upgrade_objective()``
+    # does not handle this, so we inject a safe default here.
+    for objective in inst.get("objectives") or []:
+        if "magnification" not in objective or objective["magnification"] is None:
+            logger.warning(
+                "Objective %r missing 'magnification' — defaulting to 1.0",
+                objective.get("name", "?"),
+            )
+            note = "(v1v2 pre-process): magnification was missing, defaulted to 1.0"
+            existing = objective.get("notes") or ""
+            objective["notes"] = (
+                f"{existing} {note}".strip() if existing else note
+            )
+            objective["magnification"] = 1.0
+
+    # ── Back-fill center_wavelength on multiband filters ────────────
+    # The upgrader's ``upgrade_filter_multiband()`` raises
+    # ``ValueError`` when a Multiband filter has
+    # ``center_wavelength: None`` and the model name isn't in its
+    # hard-coded ``FILTER_WAVELENGTH_MAP``.  We parse wavelengths from
+    # the model string (e.g. ``ZET405/488/561/620m`` → [405, 488, 561,
+    # 620]) so the upgrader can proceed.
+    import re as _re
+
+    for filt in inst.get("fluorescence_filters") or []:
+        if (
+            filt.get("filter_type") == "Multiband"
+            and not filt.get("center_wavelength")
+        ):
+            model = filt.get("model", "")
+            wavelengths = [int(m) for m in _re.findall(r"\d{3}", model)]
+            if wavelengths:
+                logger.warning(
+                    "Multiband filter %r (model %r) has no "
+                    "center_wavelength — parsed %s from model name",
+                    filt.get("name", "?"),
+                    model,
+                    wavelengths,
+                )
+                filt["center_wavelength"] = wavelengths
+            else:
+                logger.warning(
+                    "Multiband filter %r (model %r) has no "
+                    "center_wavelength and wavelengths could not be "
+                    "parsed from the model name — upgrade may fail",
+                    filt.get("name", "?"),
+                    model,
+                )
+
+    # ── Strip deprecated fields from motorized stages ─────────────
+    # The v2 ``MotorizedStage`` model forbids extra inputs.  Some v1
+    # instrument files carry ``stage_axis_direction`` and
+    # ``stage_axis_name`` on motorised stages — these are only valid
+    # on ``ScanningStage`` in v2.  The upgrader's
+    # ``upgrade_motorized_stages()`` doesn't strip them, so we do it
+    # here, preserving the information in ``notes``.
+    #
+    # Additionally, v1 used ``travel_unit: "degree"`` for rotation
+    # stages but v2 only accepts linear units.  We remap to
+    # ``millimeter`` and note the original value.
+    _DEPRECATED_MOTORIZED_FIELDS = ("stage_axis_direction", "stage_axis_name")
+    _VALID_TRAVEL_UNITS = {
+        "meter", "centimeter", "millimeter", "micrometer",
+        "nanometer", "inch", "pixel",
+    }
+    for stage in inst.get("motorized_stages") or []:
+        removed = {}
+        for field in _DEPRECATED_MOTORIZED_FIELDS:
+            if field in stage:
+                removed[field] = stage.pop(field)
+        if removed:
+            logger.warning(
+                "Removed deprecated fields %s from motorized_stages[%s]",
+                list(removed.keys()),
+                stage.get("name", "?"),
+            )
+            note_parts = [
+                f"(v1v2 pre-process): removed {k}={v!r}"
+                for k, v in removed.items()
+            ]
+            existing = stage.get("notes") or ""
+            stage["notes"] = (
+                f"{existing} {'; '.join(note_parts)}".strip()
+                if existing
+                else "; ".join(note_parts)
+            )
+
+        # Fix invalid travel_unit
+        tu = stage.get("travel_unit")
+        if tu and tu not in _VALID_TRAVEL_UNITS:
+            logger.warning(
+                "Stage %r has invalid travel_unit %r — "
+                "remapping to 'millimeter'",
+                stage.get("name", "?"),
+                tu,
+            )
+            note = f"(v1v2 pre-process): original travel_unit was '{tu}'"
+            existing = stage.get("notes") or ""
+            stage["notes"] = (
+                f"{existing} {note}".strip() if existing else note
+            )
+            stage["travel_unit"] = "millimeter"
+
+    # ── Normalise stage_axis_direction on scanning stages ───────────
+    # v2 ``ScanningStage`` requires ``stage_axis_direction`` to be one
+    # of the ``StageAxisDirection`` enum values.  v1 files often have
+    # free-form strings like ``"Detection Z axis. Tiger Z axis."``.
+    _VALID_AXIS_DIRECTIONS = {
+        "Detection axis", "Illumination axis", "Perpendicular axis",
+    }
+    _AXIS_DIRECTION_MAP = {
+        "detection": "Detection axis",
+        "illumination": "Illumination axis",
+        "perpendicular": "Perpendicular axis",
+    }
+    for stage in inst.get("scanning_stages") or []:
+        sad = stage.get("stage_axis_direction", "")
+        if sad and sad not in _VALID_AXIS_DIRECTIONS:
+            mapped = None
+            sad_lower = sad.lower()
+            for keyword, canonical in _AXIS_DIRECTION_MAP.items():
+                if keyword in sad_lower:
+                    mapped = canonical
+                    break
+            if mapped:
+                logger.warning(
+                    "Scanning stage %r: remapping stage_axis_direction "
+                    "%r → %r",
+                    stage.get("name", "?"),
+                    sad,
+                    mapped,
+                )
+                note = (
+                    f"(v1v2 pre-process): original "
+                    f"stage_axis_direction was '{sad}'"
+                )
+                existing = stage.get("notes") or ""
+                stage["notes"] = (
+                    f"{existing} {note}".strip() if existing else note
+                )
+                stage["stage_axis_direction"] = mapped
+            else:
+                logger.warning(
+                    "Scanning stage %r: unknown stage_axis_direction "
+                    "%r — defaulting to 'Detection axis'",
+                    stage.get("name", "?"),
+                    sad,
+                )
+                stage["stage_axis_direction"] = "Detection axis"
+    return inst
+
+
 def _upgrade_with_instrument(
     acq_data: dict, inst_data: dict
 ) -> tuple[dict, dict | None]:
@@ -122,7 +337,8 @@ def _upgrade_with_instrument(
     """
     from aind_metadata_upgrader.upgrade import Upgrade
 
-    record: dict = {"acquisition": acq_data, "instrument": inst_data}
+    sanitized_inst = _sanitize_instrument_manufacturers(inst_data)
+    record: dict = {"acquisition": acq_data, "instrument": sanitized_inst}
     upgraded = Upgrade(record, skip_metadata_validation=True)
 
     upgraded_acq = _to_json_dict(upgraded.metadata.acquisition)


### PR DESCRIPTION
Bugs Found & Fixed in _upgrade_with_instrument()
The aind-metadata-upgrader library crashes on multiple real-world v1 instrument fields. I added _sanitize_instrument_manufacturers() as a pre-processing step in upgrade_metadata.py that fixes 5 issues before passing data to the upgrader:

#	Issue	Root Cause	Fix
1	AttributeError: 'NoneType' has no attribute 'model_dump'	Organization.from_name("PhotonGear") returns None	Replace unrecognized manufacturers with "Other"
2	ValidationError: magnification — Field required	Excitation objective missing magnification	Default to 1.0
3	ValueError: Multiband filter has no center_wavelength	Filter model ZET405/488/561/620m not in upgrader's FILTER_WAVELENGTH_MAP	Parse wavelengths [405, 488, 561, 620] from model name
4	ValidationError: stage_axis_direction/name — Extra inputs not permitted	MotorizedStage v2 forbids these v1-only fields	Strip from motorized stages, preserve in notes
5	ValidationError: travel_unit — 'degree' not valid	Rotation stage uses degree but v2 only allows linear units	Remap to millimeter
6	ValidationError: stage_axis_direction — not a valid enum	Free-form strings like "Detection Z axis. Tiger Z axis."	Map to canonical "Detection axis"
All original values are preserved in notes fields so no information is lost.