### PR TITLE
Feat metadata service

### DIFF
--- a/docs/examples/test_airflow.py
+++ b/docs/examples/test_airflow.py
@@ -85,46 +85,6 @@ def _derive_subject_id(path: str) -> str:
         )
     return basename
 
-def get_additional_metadata(subject_id: str, data_directory: str): 
-    labtracks_id = subject_id.split("-")[0]
-
-    # Download subject and procedures from metadata service
-    metadata_service_url = "http://aind-metadata-service/"  # for prod
-    # metadata_service_url = "http://aind-metadata-service-dev"  # for testing
-    metadata_files = [os.path.basename(x) for x in glob(f"{data_directory}/*.json")]
-
-    # Create empty subject.json if metadata service fails or for testing
-    if "subject.json" not in metadata_files:
-        try:
-            subject_response = requests.get(
-                f"{metadata_service_url}/api/v2/subject/{labtracks_id}"
-            )
-            if subject_response.status_code in [200, 400]:
-                json_data = subject_response.json()
-                with open(f"{data_directory}/subject.json", "w") as f:
-                    json.dump(json_data, f, indent=3)
-            else:
-                subject_response.raise_for_status()
-        except Exception as e:
-            print(f"Failed to get subject from metadata service: {e}")
-            print("Creating empty subject.json file...")
-
-    # Create empty procedures.json if metadata service fails or for testing
-    if "procedures.json" not in metadata_files:
-        try:
-            procedures_response = requests.get(
-                f"{metadata_service_url}/api/v2/procedures/{labtracks_id}"
-            )
-            if procedures_response.status_code in [200, 400]:
-                json_data = procedures_response.json()
-                with open(f"{data_directory}/procedures.json", "w") as f:
-                    json.dump(json_data, f, indent=3)
-            else:
-                procedures_response.raise_for_status()
-        except Exception as e:
-            print(f"Failed to get procedures from metadata service: {e}")
-            print("Creating empty procedures.json file...")
-
 
 def submit_exaspim_job(
     source: str,
@@ -150,15 +110,12 @@ def submit_exaspim_job(
     -----
     Metadata upgrade (v1 → v2.5+) is handled automatically inside the
     SLURM job by ``imaris_job.py`` (worker 0), which has the required
-    S3 write permissions.
+    S3 write permissions.  Subject and procedures metadata are also
+    fetched from ``aind-metadata-service`` by worker 0 (see
+    ``upgrade_metadata.get_additional_metadata``).
     """
     if subject_id is None:
         subject_id = _derive_subject_id(source)
-
-    # Fetch subject.json and procedures.json from the metadata service
-    # into the dataset root (one level up from the exaSPIM/ source dir).
-    # data_directory = os.path.dirname(os.path.normpath(source))
-    # get_additional_metadata(subject_id, data_directory)
 
     acq_datetime = _parse_acq_datetime(source)
     ims_files = _discover_ims_files(source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "tensorstore==0.1.80",
     "psutil==7.2.2", 
     "boto3==1.42.36",
-    "aind-metadata-upgrader>=0.13.4"
+    "aind-metadata-upgrader>=0.13.4",
+    "requests>=2.28.0"
 ]
 
 [tool.setuptools]

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -25,7 +25,10 @@ from aind_exaspim_data_transformation.models import (
     CompressorName,
     ImarisJobSettings,
 )
-from aind_exaspim_data_transformation.upgrade_metadata import upgrade_metadata
+from aind_exaspim_data_transformation.upgrade_metadata import (
+    get_additional_metadata,
+    upgrade_metadata,
+)
 from aind_exaspim_data_transformation.utils import utils
 from aind_exaspim_data_transformation.utils.io_utils import ImarisReader
 
@@ -533,6 +536,50 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
         dataset_root_path = str(Path(parsed.path.rstrip("/")).parent)
         return f"s3://{parsed.netloc}{dataset_root_path}"
 
+    def _get_additional_metadata(self):
+        """Fetch subject.json and procedures.json from the metadata service.
+
+        Only runs when ``s3_location`` is configured.  Errors are logged
+        but do **not** abort the compression pipeline.
+        """
+        if self.job_settings.s3_location is None:
+            logging.info(
+                "No s3_location configured — skipping metadata fetch."
+            )
+            return
+
+        s3_dataset_root = self._get_dataset_root_s3(
+            self.job_settings.s3_location
+        )
+
+        logging.info(
+            "Fetching additional metadata for source_dir=%s, "
+            "s3_location=%s (dataset root: %s)",
+            self.job_settings.input_source,
+            self.job_settings.s3_location,
+            s3_dataset_root,
+        )
+        try:
+            get_additional_metadata(
+                source_dir=str(self.job_settings.input_source),
+                s3_location=s3_dataset_root,
+                dry_run=False,
+            )
+            logging.info("Additional metadata fetch completed successfully.")
+        except (
+            OSError,
+            ValueError,
+            RuntimeError,
+            ClientError,
+            BotoCoreError,
+        ) as exc:
+            logging.error(
+                "METADATA FETCH FAILED — continuing with compression. "
+                "Error: %s",
+                exc,
+                exc_info=True,
+            )
+
     def _upgrade_metadata(self):
         """Upgrade v1 metadata files and upload to S3.
 
@@ -822,6 +869,7 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             self.job_settings.partition_to_process,
         )
         if self.job_settings.partition_to_process == 0:
+            self._get_additional_metadata()
             self._upgrade_metadata()
             self._upload_derivatives_folder()
 

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -93,6 +93,22 @@ def _upload_bytes_to_s3(body: bytes, s3_uri: str) -> None:
     logger.info("Uploaded %d bytes → %s", len(body), s3_uri)
 
 
+def _s3_object_exists(s3_uri: str) -> bool:
+    """Return True if an object exists at *s3_uri*, False otherwise.
+
+    Uses a lightweight ``head_object`` call.  Any error (permissions,
+    network, etc.) is treated as "not found" so the caller can safely
+    fall through to a fetch-from-source path.
+    """
+    try:
+        bucket, key = _parse_s3_uri(s3_uri)
+        s3 = boto3.client("s3")
+        s3.head_object(Bucket=bucket, Key=key)
+        return True
+    except Exception:
+        return False
+
+
 def _backup_original_to_s3(
     local_path: Path, s3_location: str, filename: str
 ) -> None:
@@ -510,6 +526,8 @@ def get_additional_metadata(
 
     for filename, url in endpoints.items():
         local_path = metadata_dir / filename
+
+        # 1. Skip if the file already exists on the local filesystem.
         if local_path.exists():
             logger.info(
                 "%s already exists at %s — skipping download.",
@@ -518,6 +536,20 @@ def get_additional_metadata(
             )
             continue
 
+        # 2. Skip if the file was already placed in S3 by the Airflow
+        #    gather_preliminary_metadata step.
+        if not dry_run:
+            s3_dest = f"{s3_location.rstrip('/')}/{filename}"
+            if _s3_object_exists(s3_dest):
+                logger.info(
+                    "%s already exists in S3 at %s "
+                    "(placed by gather_preliminary_metadata) — skipping.",
+                    filename,
+                    s3_dest,
+                )
+                continue
+
+        # 3. Fallback: fetch from aind-metadata-service directly.
         try:
             response = requests.get(url, timeout=30)
             if response.status_code in (200, 400):

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -23,6 +23,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import boto3
+import requests
 from packaging import version
 
 from aind_exaspim_data_transformation.utils import utils
@@ -35,6 +36,13 @@ _METADATA_FILES = ("acquisition.json", "instrument.json")
 
 # Schema version threshold — anything below this gets upgraded
 _V2_THRESHOLD = "2.0.0"
+
+# Metadata service URL (prod)
+# For dev/testing use: "http://aind-metadata-service-dev"
+_METADATA_SERVICE_URL = "http://aind-metadata-service"
+
+# Additional metadata files fetched from the metadata service
+_ADDITIONAL_METADATA_FILES = ("subject.json", "procedures.json")
 
 
 def _load_metadata_file(path: Path) -> dict | None:
@@ -444,6 +452,106 @@ def _upload_upgraded_outputs(
         "Upgraded instrument.json to schema_version %s",
         upgraded_inst.get("schema_version"),
     )
+
+
+def _derive_subject_id(source_dir: str) -> str:
+    """Best-effort subject ID from the dataset folder name.
+
+    The dataset root is one level above *source_dir* (the modality
+    subfolder).  For a path like ``…/exaSPIM_765830_2025-11-21_12-01-47/exaSPIM``,
+    the dataset folder is ``exaSPIM_765830_2025-11-21_12-01-47`` and the
+    returned subject ID is ``765830``.
+    """
+    dataset_dir = Path(source_dir).resolve().parent
+    basename = dataset_dir.name
+    if "_" in basename:
+        # exaSPIM_765830_… → 765830   (second segment)
+        # other_format_…   → other    (first segment)
+        parts = basename.split("_")
+        return parts[1] if "ExaSPIM" in basename or "exaSPIM" in basename else parts[0]
+    return basename
+
+
+def get_additional_metadata(
+    source_dir: str, s3_location: str, dry_run: bool = False
+) -> None:
+    """Fetch subject.json and procedures.json from aind-metadata-service.
+
+    Downloads metadata files that are not already present in the local
+    dataset directory and uploads them to the S3 dataset root.  Errors
+    are logged but do **not** abort the pipeline.
+
+    Parameters
+    ----------
+    source_dir : str
+        Path to the modality subfolder (e.g. ``…/exaSPIM``).
+        Metadata is read from / written to ``Path(source_dir).parent``.
+    s3_location : str
+        S3 URI of the dataset root.
+    dry_run : bool
+        If True, skip S3 uploads (useful for local testing).
+    """
+    metadata_dir = Path(source_dir).parent
+    subject_id = _derive_subject_id(source_dir)
+    labtracks_id = subject_id.split("-")[0]
+
+    logger.info(
+        "Fetching additional metadata for subject_id=%s "
+        "(labtracks_id=%s) from %s",
+        subject_id,
+        labtracks_id,
+        _METADATA_SERVICE_URL,
+    )
+
+    endpoints = {
+        "subject.json": f"{_METADATA_SERVICE_URL}/api/v2/subject/{labtracks_id}",
+        "procedures.json": f"{_METADATA_SERVICE_URL}/api/v2/procedures/{labtracks_id}",
+    }
+
+    for filename, url in endpoints.items():
+        local_path = metadata_dir / filename
+        if local_path.exists():
+            logger.info(
+                "%s already exists at %s — skipping download.",
+                filename,
+                local_path,
+            )
+            continue
+
+        try:
+            response = requests.get(url, timeout=30)
+            if response.status_code in (200, 400):
+                json_data = response.json()
+                body = json.dumps(json_data, indent=3).encode("utf-8")
+
+                # Write locally so other steps can see it
+                local_path.write_bytes(body)
+                logger.info("Wrote %s to %s", filename, local_path)
+
+                # Upload to S3
+                if dry_run:
+                    logger.info(
+                        "[DRY RUN] Would upload %s → %s/%s",
+                        filename,
+                        s3_location.rstrip("/"),
+                        filename,
+                    )
+                else:
+                    s3_dest = f"{s3_location.rstrip('/')}/{filename}"
+                    _upload_bytes_to_s3(body, s3_dest)
+            else:
+                logger.warning(
+                    "Metadata service returned HTTP %s for %s — skipping.",
+                    response.status_code,
+                    url,
+                )
+        except Exception as exc:
+            logger.error(
+                "Failed to fetch %s from metadata service: %s",
+                filename,
+                exc,
+                exc_info=True,
+            )
 
 
 def upgrade_metadata(

--- a/tests/test_upgrade_metadata.py
+++ b/tests/test_upgrade_metadata.py
@@ -11,6 +11,7 @@ from aind_exaspim_data_transformation.upgrade_metadata import (
     _derive_subject_id,
     _load_metadata_file,
     _needs_upgrade,
+    _s3_object_exists,
     _write_json_to_tempfile,
     get_additional_metadata,
     upgrade_metadata,
@@ -565,13 +566,17 @@ class TestDeriveSubjectId(unittest.TestCase):
         self.assertEqual(_derive_subject_id(path), "123456")
 
 
+@patch("aind_exaspim_data_transformation.upgrade_metadata._s3_object_exists")
 @patch("aind_exaspim_data_transformation.upgrade_metadata._upload_bytes_to_s3")
 class TestGetAdditionalMetadata(unittest.TestCase):
     """Tests for get_additional_metadata."""
 
     @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
-    def test_fetches_and_uploads_both_files(self, mock_get, mock_upload):
-        """Happy path: both subject.json and procedures.json fetched and uploaded."""
+    def test_fetches_and_uploads_both_files(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
+        """Happy path: not local, not in S3 → fetch and upload."""
+        mock_s3_exists.return_value = False
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"name": "test_subject"}
@@ -595,7 +600,9 @@ class TestGetAdditionalMetadata(unittest.TestCase):
             self.assertTrue((dataset_dir / "procedures.json").exists())
 
     @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
-    def test_skips_existing_files(self, mock_get, mock_upload):
+    def test_skips_existing_local_files(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
         """Files already present locally are not re-fetched."""
         with tempfile.TemporaryDirectory() as tmpdir:
             dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
@@ -613,10 +620,63 @@ class TestGetAdditionalMetadata(unittest.TestCase):
 
             mock_get.assert_not_called()
             mock_upload.assert_not_called()
+            # S3 check not even reached when local file exists
+            mock_s3_exists.assert_not_called()
 
     @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
-    def test_http_error_does_not_raise(self, mock_get, mock_upload):
+    def test_skips_when_already_in_s3(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
+        """Files placed in S3 by gather_preliminary_metadata are not re-fetched."""
+        mock_s3_exists.return_value = True
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+            )
+
+            # S3 was checked for both files
+            self.assertEqual(mock_s3_exists.call_count, 2)
+            # No HTTP fetch, no upload
+            mock_get.assert_not_called()
+            mock_upload.assert_not_called()
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_s3_check_failure_falls_through_to_fetch(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
+        """If S3 check fails (e.g., permissions), fall through to fetch."""
+        mock_s3_exists.return_value = False  # treated as not found
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "test_subject"}
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+            )
+
+            # Falls through to fetch
+            self.assertEqual(mock_get.call_count, 2)
+            self.assertEqual(mock_upload.call_count, 2)
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_http_error_does_not_raise(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
         """HTTP errors are logged but do not crash."""
+        mock_s3_exists.return_value = False
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_get.return_value = mock_response
@@ -635,10 +695,13 @@ class TestGetAdditionalMetadata(unittest.TestCase):
             mock_upload.assert_not_called()
 
     @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
-    def test_network_exception_does_not_raise(self, mock_get, mock_upload):
+    def test_network_exception_does_not_raise(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
         """Network errors are caught and logged."""
         import requests
 
+        mock_s3_exists.return_value = False
         mock_get.side_effect = requests.ConnectionError("timeout")
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -655,8 +718,10 @@ class TestGetAdditionalMetadata(unittest.TestCase):
             mock_upload.assert_not_called()
 
     @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
-    def test_dry_run_skips_s3_upload(self, mock_get, mock_upload):
-        """dry_run=True writes locally but does not upload to S3."""
+    def test_dry_run_skips_s3_check_and_upload(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
+        """dry_run=True skips S3 check, writes locally, no upload."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"name": "test_subject"}
@@ -676,12 +741,16 @@ class TestGetAdditionalMetadata(unittest.TestCase):
             # Files written locally
             self.assertTrue((dataset_dir / "subject.json").exists())
             self.assertTrue((dataset_dir / "procedures.json").exists())
-            # No S3 uploads
+            # No S3 check or upload in dry_run
+            mock_s3_exists.assert_not_called()
             mock_upload.assert_not_called()
 
     @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
-    def test_status_400_still_writes(self, mock_get, mock_upload):
+    def test_status_400_still_writes(
+        self, mock_get, mock_upload, mock_s3_exists
+    ):
         """HTTP 400 is treated as a valid response (writes the JSON body)."""
+        mock_s3_exists.return_value = False
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_response.json.return_value = {"message": "not found"}
@@ -699,6 +768,44 @@ class TestGetAdditionalMetadata(unittest.TestCase):
 
             self.assertEqual(mock_upload.call_count, 2)
             self.assertTrue((dataset_dir / "subject.json").exists())
+
+
+class TestS3ObjectExists(unittest.TestCase):
+    """Tests for _s3_object_exists helper."""
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.boto3.client")
+    def test_returns_true_when_object_exists(self, mock_boto):
+        mock_s3 = MagicMock()
+        mock_boto.return_value = mock_s3
+        self.assertTrue(
+            _s3_object_exists("s3://bucket/key/subject.json")
+        )
+        mock_s3.head_object.assert_called_once_with(
+            Bucket="bucket", Key="key/subject.json"
+        )
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.boto3.client")
+    def test_returns_false_on_client_error(self, mock_boto):
+        from botocore.exceptions import ClientError
+
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}},
+            "HeadObject",
+        )
+        mock_boto.return_value = mock_s3
+        self.assertFalse(
+            _s3_object_exists("s3://bucket/key/subject.json")
+        )
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.boto3.client")
+    def test_returns_false_on_any_exception(self, mock_boto):
+        mock_s3 = MagicMock()
+        mock_s3.head_object.side_effect = Exception("network error")
+        mock_boto.return_value = mock_s3
+        self.assertFalse(
+            _s3_object_exists("s3://bucket/key/subject.json")
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_upgrade_metadata.py
+++ b/tests/test_upgrade_metadata.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from aind_exaspim_data_transformation.upgrade_metadata import (
+    _derive_subject_id,
     _load_metadata_file,
     _needs_upgrade,
     _write_json_to_tempfile,
+    get_additional_metadata,
     upgrade_metadata,
 )
 
@@ -537,6 +539,166 @@ class TestUpgradeMetadataRealUpgrader(unittest.TestCase):
                     f"{uploaded.get('schema_version')} "
                     f"which is below 2.0.0",
                 )
+
+
+class TestDeriveSubjectId(unittest.TestCase):
+    """Tests for _derive_subject_id helper."""
+
+    def test_exaspim_path(self):
+        """Subject ID is the second underscore-delimited segment."""
+        path = "/allen/aind/stage/exaSPIM/exaSPIM_765830_2025-11-21_12-01-47/exaSPIM"
+        self.assertEqual(_derive_subject_id(path), "765830")
+
+    def test_non_exaspim_path(self):
+        """Fallback: first underscore-delimited segment."""
+        path = "/data/my_dataset_2025-01-01/SPIM"
+        self.assertEqual(_derive_subject_id(path), "my")
+
+    def test_no_underscores(self):
+        """No underscores returns the full folder name."""
+        path = "/data/singlename/exaSPIM"
+        self.assertEqual(_derive_subject_id(path), "singlename")
+
+    def test_exaspim_uppercase_variant(self):
+        """ExaSPIM in folder name triggers second-segment extraction."""
+        path = "/data/ExaSPIM_123456_2026-04-28/exaSPIM"
+        self.assertEqual(_derive_subject_id(path), "123456")
+
+
+@patch("aind_exaspim_data_transformation.upgrade_metadata._upload_bytes_to_s3")
+class TestGetAdditionalMetadata(unittest.TestCase):
+    """Tests for get_additional_metadata."""
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_fetches_and_uploads_both_files(self, mock_get, mock_upload):
+        """Happy path: both subject.json and procedures.json fetched and uploaded."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "test_subject"}
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+            )
+
+            self.assertEqual(mock_get.call_count, 2)
+            # Two files uploaded to S3
+            self.assertEqual(mock_upload.call_count, 2)
+            # Both files written locally
+            self.assertTrue((dataset_dir / "subject.json").exists())
+            self.assertTrue((dataset_dir / "procedures.json").exists())
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_skips_existing_files(self, mock_get, mock_upload):
+        """Files already present locally are not re-fetched."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            # Pre-create both files
+            (dataset_dir / "subject.json").write_text("{}")
+            (dataset_dir / "procedures.json").write_text("{}")
+
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+            )
+
+            mock_get.assert_not_called()
+            mock_upload.assert_not_called()
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_http_error_does_not_raise(self, mock_get, mock_upload):
+        """HTTP errors are logged but do not crash."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            # Should not raise
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+            )
+
+            mock_upload.assert_not_called()
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_network_exception_does_not_raise(self, mock_get, mock_upload):
+        """Network errors are caught and logged."""
+        import requests
+
+        mock_get.side_effect = requests.ConnectionError("timeout")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            # Should not raise
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+            )
+
+            mock_upload.assert_not_called()
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_dry_run_skips_s3_upload(self, mock_get, mock_upload):
+        """dry_run=True writes locally but does not upload to S3."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"name": "test_subject"}
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+                dry_run=True,
+            )
+
+            # Files written locally
+            self.assertTrue((dataset_dir / "subject.json").exists())
+            self.assertTrue((dataset_dir / "procedures.json").exists())
+            # No S3 uploads
+            mock_upload.assert_not_called()
+
+    @patch("aind_exaspim_data_transformation.upgrade_metadata.requests.get")
+    def test_status_400_still_writes(self, mock_get, mock_upload):
+        """HTTP 400 is treated as a valid response (writes the JSON body)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {"message": "not found"}
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dataset_dir = Path(tmpdir) / "exaSPIM_765830_2025-11-21"
+            source_dir = dataset_dir / "exaSPIM"
+            source_dir.mkdir(parents=True)
+
+            get_additional_metadata(
+                str(source_dir),
+                "s3://test-bucket/test-dataset",
+            )
+
+            self.assertEqual(mock_upload.call_count, 2)
+            self.assertTrue((dataset_dir / "subject.json").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added _s3_object_exists(s3_uri) — lightweight head_object check that returns False on any error (safe fallback)
Updated get_additional_metadata() loop to a 3-tier check per file:
Local file exists → skip (unchanged)
S3 object exists (from gather_preliminary_metadata) → skip with log message
Neither → fetch from metadata service, write locally, upload to S3 (fallback)
dry_run=True skips the S3 check entirely (no point checking if we won't upload)
test_upgrade_metadata.py:

Added TestS3ObjectExists class (3 tests: exists, 404, generic error)
Added test_skips_when_already_in_s3 — verifies no HTTP fetch when S3 has the files
Added test_s3_check_failure_falls_through_to_fetch — verifies safe fallback
Updated all existing tests to mock _s3_object_exists alongside the other mocks
