### PR TITLE
Fix multichan resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
     "tensorstore==0.1.80",
     "psutil==7.2.2", 
     "boto3==1.42.36",
-    "aind-metadata-upgrader>=0.13.4",
+    "aind-data-schema>=2.8.0,<3",
+    "aind-data-schema-models>=5.7.3,<6",
+    "aind-metadata-upgrader>=0.13.4,<0.14",
     "requests>=2.28.0"
 ]
 

--- a/src/aind_exaspim_data_transformation/__init__.py
+++ b/src/aind_exaspim_data_transformation/__init__.py
@@ -1,6 +1,6 @@
 """Init package"""
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 __authors__ = ["Carson Berry"]
 __author_emails__ = [
     "carson.berry@alleninstitute.org",

--- a/src/aind_exaspim_data_transformation/imaris_job.py
+++ b/src/aind_exaspim_data_transformation/imaris_job.py
@@ -226,6 +226,175 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
         return [z, y, x]
 
     @staticmethod
+    def _get_tile_voxel_resolution_from_acquisition(
+        acquisition_path: Path,
+        tile_filename: str,
+    ) -> Optional[List[float]]:
+        """
+        Get the per-tile voxel resolution from an ``acquisition.json`` file.
+
+        Tiles in an acquisition can be acquired at different resolutions
+        (e.g. one channel imaged at higher Z-step than another). This
+        method matches the requested tile by ``file_name`` and returns the
+        scale transform declared for that specific tile, so each channel's
+        ``zarr.json`` can carry its own ``coordinateTransformations``.
+
+        The acquisition.json schema stores ``scale`` in ``[X, Y, Z]``
+        order; this method returns ``[Z, Y, X]`` to match the convention
+        used by the writer pipeline.
+
+        Parameters
+        ----------
+        acquisition_path : Path
+            Path to the ``acquisition.json`` file.
+        tile_filename : str
+            Basename of the Imaris file to look up (e.g.
+            ``"tile_000000_ch_561.ims"``).
+
+        Returns
+        -------
+        List[float] or None
+            Voxel size as ``[Z, Y, X]`` in micrometres, or ``None`` if the
+            file does not exist, the tile is not found in the manifest, or
+            no scale transform is present for that tile. Callers are
+            expected to fall back to the dataset-level resolution or to
+            the Imaris file metadata in that case.
+        """
+        if not acquisition_path.is_file():
+            return None
+
+        try:
+            acquisition_config = utils.read_json_as_dict(acquisition_path)
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.warning(
+                "Could not parse acquisition.json for tile voxel "
+                "resolution: %s",
+                exc,
+            )
+            return None
+
+        schema_version_str = (
+            acquisition_config.get("schema_version") or "0.0.0"
+        )
+
+        if version.parse(schema_version_str) >= version.parse("2.0.0"):
+            return ImarisCompressionJob._get_tile_voxel_resolution_schema_2(
+                acquisition_config, tile_filename
+            )
+
+        return ImarisCompressionJob._get_tile_voxel_resolution_schema_1(
+            acquisition_config, tile_filename
+        )
+
+    @staticmethod
+    def _get_tile_voxel_resolution_schema_1(
+        acquisition_config: Dict,
+        tile_filename: str,
+    ) -> Optional[List[float]]:
+        """Look up a per-tile scale transform in schema v1 ``tiles``."""
+        for tile in acquisition_config.get("tiles", []):
+            if tile.get("file_name") != tile_filename:
+                continue
+
+            for transform in tile.get("coordinate_transformations", []):
+                if transform.get("type") != "scale":
+                    continue
+
+                scale = transform.get("scale", [])
+                if len(scale) != 3:
+                    logging.warning(
+                        "Unexpected scale length %d for tile %s; "
+                        "expected 3 (X, Y, Z).",
+                        len(scale),
+                        tile_filename,
+                    )
+                    return None
+
+                # acquisition.json: scale = [X, Y, Z]
+                x = float(scale[0])
+                y = float(scale[1])
+                z = float(scale[2])
+                voxel_size_zyx = [z, y, x]
+                logging.info(
+                    "Tile %s: acquisition.json voxel resolution ZYX (µm)"
+                    " = %s",
+                    tile_filename,
+                    voxel_size_zyx,
+                )
+                return voxel_size_zyx
+
+            logging.warning(
+                "Tile '%s' has no scale transform in acquisition.json; "
+                "falling back to dataset-level resolution.",
+                tile_filename,
+            )
+            return None
+
+        logging.warning(
+            "Tile '%s' not found in acquisition.json tiles list; "
+            "falling back to dataset-level resolution.",
+            tile_filename,
+        )
+        return None
+
+    @staticmethod
+    def _get_tile_voxel_resolution_schema_2(
+        acquisition_config: Dict,
+        tile_filename: str,
+    ) -> Optional[List[float]]:
+        """Look up a per-tile scale transform in schema v2 ``data_streams``."""
+        for stream in acquisition_config.get("data_streams", []):
+            for config in stream.get("configurations", []):
+                for image in config.get("images", []):
+                    if image.get("file_name") != tile_filename:
+                        continue
+
+                    transforms = image.get(
+                        "image_to_acquisition_transform", []
+                    )
+                    for transform in transforms:
+                        if transform.get("object_type") != "Scale":
+                            continue
+
+                        scale = transform.get("scale", [])
+                        if len(scale) != 3:
+                            logging.warning(
+                                "Unexpected scale length %d for tile %s; "
+                                "expected 3 (X, Y, Z).",
+                                len(scale),
+                                tile_filename,
+                            )
+                            return None
+
+                        # acquisition.json: scale = [X, Y, Z]
+                        x = float(scale[0])
+                        y = float(scale[1])
+                        z = float(scale[2])
+                        voxel_size_zyx = [z, y, x]
+                        logging.info(
+                            "Tile %s: acquisition.json voxel resolution "
+                            "ZYX (µm) = %s",
+                            tile_filename,
+                            voxel_size_zyx,
+                        )
+                        return voxel_size_zyx
+
+                    logging.warning(
+                        "Tile '%s' has no Scale transform in "
+                        "acquisition.json (schema v2); falling back to "
+                        "dataset-level resolution.",
+                        tile_filename,
+                    )
+                    return None
+
+        logging.warning(
+            "Tile '%s' not found in acquisition.json data_streams "
+            "(schema v2); falling back to dataset-level resolution.",
+            tile_filename,
+        )
+        return None
+
+    @staticmethod
     def _get_tile_translation_from_acquisition(
         acquisition_path: Path,
         tile_filename: str,
@@ -370,21 +539,26 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             Tuple[int, int, int], tuple(self.job_settings.scale_factor)
         )
 
-        # Try to get voxel resolution from acquisition.json if it exists
-        # Otherwise, it will be extracted from each Imaris file individually
+        # Try to get a dataset-level voxel resolution from acquisition.json
+        # if it exists. This is used only as a fallback when a tile is not
+        # listed in the acquisition manifest or has no per-tile scale
+        # transform. Per-tile resolution is preferred and resolved inside
+        # the loop below so multi-channel datasets with different
+        # resolutions get distinct ``zarr.json`` scale transforms.
         # acquisition.json lives one level above the input_source (exaSPIM) folder
         acquisition_path = input_source_path.parent.joinpath(
             "acquisition.json"
         )
 
-        voxel_size_zyx = None
+        dataset_voxel_size_zyx: Optional[List[float]] = None
         if acquisition_path.exists():
             try:
-                voxel_size_zyx = self._get_voxel_resolution(
+                dataset_voxel_size_zyx = self._get_voxel_resolution(
                     acquisition_path=acquisition_path
                 )
                 logging.info(
-                    f"Using voxel size from acquisition.json: {voxel_size_zyx}"
+                    "Dataset-level voxel size from acquisition.json: %s",
+                    dataset_voxel_size_zyx,
                 )
             except Exception as e:
                 logging.warning(
@@ -408,8 +582,15 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             logging.info(f"Converting {stack}")
             stack_name = stack.stem
 
-            # If voxel size wasn't available from acquisition.json,
-            # extract it from the Imaris file
+            # Resolve voxel size per stack so each channel/tile can carry
+            # its own scale transform in the written zarr.json.
+            # Priority: per-tile acquisition lookup → dataset-level
+            # acquisition value → Imaris file metadata.
+            voxel_size_zyx = self._get_tile_voxel_resolution_from_acquisition(
+                acquisition_path, stack.name
+            )
+            if voxel_size_zyx is None:
+                voxel_size_zyx = dataset_voxel_size_zyx
             if voxel_size_zyx is None:
                 voxel_size_zyx = self._get_voxel_size_from_imaris(stack)
 
@@ -816,20 +997,23 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             )
             return
 
-        # Try to read voxel size from acquisition.json once
+        # Read a dataset-level voxel size from acquisition.json once as a
+        # fallback. The per-tile lookup happens inside
+        # ``_process_file_shards`` so each channel/tile can carry its own
+        # scale transform in the written zarr.json.
         # acquisition.json lives one level above the input_source (exaSPIM) folder
         acquisition_path = Path(
             self.job_settings.input_source
         ).parent.joinpath("acquisition.json")
-        voxel_size_zyx = None
+        dataset_voxel_size_zyx: Optional[List[float]] = None
         if acquisition_path.exists():
             try:
-                voxel_size_zyx = self._get_voxel_resolution(
+                dataset_voxel_size_zyx = self._get_voxel_resolution(
                     acquisition_path=acquisition_path
                 )
                 logging.info(
-                    "Using voxel size from acquisition.json: %s",
-                    voxel_size_zyx,
+                    "Dataset-level voxel size from acquisition.json: %s",
+                    dataset_voxel_size_zyx,
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 logging.warning(
@@ -876,7 +1060,7 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
                 self._process_file_shards(
                     stack_path=stack_path,
                     shard_indices=shard_indices,
-                    voxel_size_zyx=voxel_size_zyx,
+                    dataset_voxel_size_zyx=dataset_voxel_size_zyx,
                     dask_client=dask_client,
                     acquisition_path=acquisition_path,
                 )
@@ -890,7 +1074,7 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
         self,
         stack_path: Path,
         shard_indices: List[tuple[int, int, int]],
-        voxel_size_zyx: Optional[List[float]] = None,
+        dataset_voxel_size_zyx: Optional[List[float]] = None,
         dask_client: Optional[Any] = None,
         acquisition_path: Optional[Path] = None,
     ) -> None:
@@ -908,6 +1092,19 @@ class ImarisCompressionJob(GenericEtl[ImarisJobSettings]):
             bucket_name = parsed.netloc
             output_path = Path(parsed.path.lstrip("/"))
 
+        # Resolve voxel size per stack so each channel/tile can carry
+        # its own scale transform in the written zarr.json.
+        # Priority: per-tile acquisition lookup → dataset-level
+        # acquisition value → Imaris file metadata.
+        voxel_size_zyx: Optional[List[float]] = None
+        if acquisition_path is not None:
+            voxel_size_zyx = (
+                self._get_tile_voxel_resolution_from_acquisition(
+                    acquisition_path, stack_path.name
+                )
+            )
+        if voxel_size_zyx is None:
+            voxel_size_zyx = dataset_voxel_size_zyx
         if voxel_size_zyx is None:
             voxel_size_zyx = self._get_voxel_size_from_imaris(stack_path)
 

--- a/src/aind_exaspim_data_transformation/upgrade_metadata.py
+++ b/src/aind_exaspim_data_transformation/upgrade_metadata.py
@@ -352,6 +352,53 @@ def _sanitize_instrument_manufacturers(inst_data: dict) -> dict:
     return inst
 
 
+def _coerce_instrument_id(
+    acq_data: dict, inst_data: dict
+) -> dict:
+    """Ensure ``acq_data["instrument_id"]`` is non-empty before upgrade.
+
+    aind-data-schema >= 2.8 enforces that ``Acquisition.instrument_id``
+    must be a non-empty string whenever ``data_streams`` is populated.
+    v1 acquisition.json files often carry an empty string or the literal
+    ``"None"`` for ``instrument_id``; in those cases we fall back to the
+    instrument file's ``instrument_id`` so the upstream ``Upgrade()``
+    validator sees a usable value.
+
+    Returns a shallow copy of ``acq_data`` with ``instrument_id`` filled
+    in when possible. If neither side has a usable value, the original
+    (empty) value is preserved and ``Upgrade()`` will surface the
+    validation error -- this is the desired behaviour so the caller
+    knows the upgrade is incomplete.
+    """
+    acq = dict(acq_data)
+    current = acq.get("instrument_id")
+    if isinstance(current, str) and current.strip() and current != "None":
+        return acq
+
+    fallback = inst_data.get("instrument_id") if inst_data else None
+    if (
+        isinstance(fallback, str)
+        and fallback.strip()
+        and fallback != "None"
+    ):
+        logger.info(
+            "Pre-seeding acquisition.instrument_id=%r from instrument.json "
+            "(acquisition had %r).",
+            fallback,
+            current,
+        )
+        acq["instrument_id"] = fallback
+    else:
+        logger.warning(
+            "Cannot pre-seed acquisition.instrument_id: acquisition has "
+            "%r and instrument has %r. Upgrade may fail validation under "
+            "aind-data-schema >= 2.8.",
+            current,
+            fallback,
+        )
+    return acq
+
+
 def _upgrade_with_instrument(
     acq_data: dict, inst_data: dict
 ) -> tuple[dict, dict | None]:
@@ -362,7 +409,8 @@ def _upgrade_with_instrument(
     from aind_metadata_upgrader.upgrade import Upgrade
 
     sanitized_inst = _sanitize_instrument_manufacturers(inst_data)
-    record: dict = {"acquisition": acq_data, "instrument": sanitized_inst}
+    seeded_acq = _coerce_instrument_id(acq_data, sanitized_inst)
+    record: dict = {"acquisition": seeded_acq, "instrument": sanitized_inst}
     upgraded = Upgrade(record, skip_metadata_validation=True)
 
     upgraded_acq = _to_json_dict(upgraded.metadata.acquisition)

--- a/tests/test_imaris_job.py
+++ b/tests/test_imaris_job.py
@@ -237,6 +237,339 @@ class TestImarisCompressionJob(unittest.TestCase):
         self.assertEqual(result, [2.0, 1.0, 1.0])
         mock_reader.get_voxel_size.assert_called_once()
 
+    @patch(
+        "aind_exaspim_data_transformation.imaris_job.utils.read_json_as_dict"
+    )
+    def test_get_tile_voxel_resolution_schema_1(self, mock_read_json):
+        """Per-tile schema v1 lookup returns the matching tile's scale."""
+        mock_acq_path = MagicMock()
+        mock_acq_path.is_file.return_value = True
+
+        mock_read_json.return_value = {
+            "schema_version": "1.0.0",
+            "tiles": [
+                {
+                    "file_name": "tile_000000_ch_488.ims",
+                    "coordinate_transformations": [
+                        {"type": "scale", "scale": [0.5, 0.5, 1.0]}
+                    ],
+                },
+                {
+                    "file_name": "tile_000001_ch_561.ims",
+                    "coordinate_transformations": [
+                        {"type": "scale", "scale": [0.75, 0.75, 2.0]}
+                    ],
+                },
+            ],
+        }
+
+        result_488 = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "tile_000000_ch_488.ims"
+            )
+        )
+        result_561 = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "tile_000001_ch_561.ims"
+            )
+        )
+
+        # acquisition.json: [X, Y, Z] -> return as [Z, Y, X]
+        self.assertEqual(result_488, [1.0, 0.5, 0.5])
+        self.assertEqual(result_561, [2.0, 0.75, 0.75])
+
+    @patch(
+        "aind_exaspim_data_transformation.imaris_job.utils.read_json_as_dict"
+    )
+    def test_get_tile_voxel_resolution_schema_2(self, mock_read_json):
+        """Per-tile schema v2 lookup walks data_streams.configurations."""
+        mock_acq_path = MagicMock()
+        mock_acq_path.is_file.return_value = True
+
+        mock_read_json.return_value = {
+            "schema_version": "2.0.0",
+            "data_streams": [
+                {
+                    "configurations": [
+                        {
+                            "images": [
+                                {
+                                    "file_name": "tile_000000_ch_488.ims",
+                                    "image_to_acquisition_transform": [
+                                        {
+                                            "object_type": "Scale",
+                                            "scale": [0.5, 0.5, 1.0],
+                                        }
+                                    ],
+                                },
+                                {
+                                    "file_name": "tile_000001_ch_561.ims",
+                                    "image_to_acquisition_transform": [
+                                        {
+                                            "object_type": "Scale",
+                                            "scale": [0.75, 0.75, 2.0],
+                                        }
+                                    ],
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ],
+        }
+
+        result_488 = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "tile_000000_ch_488.ims"
+            )
+        )
+        result_561 = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "tile_000001_ch_561.ims"
+            )
+        )
+
+        self.assertEqual(result_488, [1.0, 0.5, 0.5])
+        self.assertEqual(result_561, [2.0, 0.75, 0.75])
+
+    @patch(
+        "aind_exaspim_data_transformation.imaris_job.utils.read_json_as_dict"
+    )
+    def test_get_tile_voxel_resolution_unknown_tile_returns_none(
+        self, mock_read_json
+    ):
+        """Unknown filename returns None instead of raising."""
+        mock_acq_path = MagicMock()
+        mock_acq_path.is_file.return_value = True
+
+        mock_read_json.return_value = {
+            "schema_version": "1.0.0",
+            "tiles": [
+                {
+                    "file_name": "tile_000000_ch_488.ims",
+                    "coordinate_transformations": [
+                        {"type": "scale", "scale": [0.5, 0.5, 1.0]}
+                    ],
+                }
+            ],
+        }
+
+        result = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "tile_does_not_exist.ims"
+            )
+        )
+
+        self.assertIsNone(result)
+
+    @patch(
+        "aind_exaspim_data_transformation.imaris_job.utils.read_json_as_dict"
+    )
+    def test_get_tile_voxel_resolution_no_scale_transform_returns_none(
+        self, mock_read_json
+    ):
+        """Matched tile with no scale transform returns None."""
+        mock_acq_path = MagicMock()
+        mock_acq_path.is_file.return_value = True
+
+        mock_read_json.return_value = {
+            "schema_version": "1.0.0",
+            "tiles": [
+                {
+                    "file_name": "tile_000000_ch_488.ims",
+                    "coordinate_transformations": [
+                        {"type": "translation", "translation": [0, 0, 0]}
+                    ],
+                }
+            ],
+        }
+
+        result = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "tile_000000_ch_488.ims"
+            )
+        )
+
+        self.assertIsNone(result)
+
+    def test_get_tile_voxel_resolution_missing_file_returns_none(self):
+        """Missing acquisition.json returns None (no exception)."""
+        mock_acq_path = MagicMock()
+        mock_acq_path.is_file.return_value = False
+
+        result = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "anything.ims"
+            )
+        )
+
+        self.assertIsNone(result)
+
+    @patch(
+        "aind_exaspim_data_transformation.imaris_job.utils.read_json_as_dict"
+    )
+    def test_get_tile_voxel_resolution_parse_error_returns_none(
+        self, mock_read_json
+    ):
+        """A read/parse error is swallowed and returns None."""
+        mock_acq_path = MagicMock()
+        mock_acq_path.is_file.return_value = True
+        mock_read_json.side_effect = ValueError("bad json")
+
+        result = (
+            ImarisCompressionJob._get_tile_voxel_resolution_from_acquisition(
+                mock_acq_path, "anything.ims"
+            )
+        )
+
+        self.assertIsNone(result)
+
+    @patch(
+        "aind_exaspim_data_transformation.imaris_job.imaris_to_zarr_distributed"
+    )
+    @patch("aind_exaspim_data_transformation.imaris_job.Path")
+    def test_write_stacks_per_tile_resolution_distinct_per_channel(
+        self, mock_path_cls, mock_distributed_writer
+    ):
+        """Two stacks with different per-tile scales produce two distinct
+        ``voxel_size`` kwargs passed to the writer (regression test for
+        the shared-resolution bug)."""
+        settings = ImarisJobSettings(
+            input_source="/fake/input",
+            output_directory="/fake/output",
+            num_of_partitions=1,
+            partition_to_process=0,
+            use_tensorstore=True,
+            translate_imaris_pyramid=False,
+        )
+        job = ImarisCompressionJob(job_settings=settings)
+
+        mock_stack1 = MagicMock()
+        mock_stack1.stem = "tile_000000_ch_488"
+        mock_stack1.name = "tile_000000_ch_488.ims"
+        mock_stack1.__str__ = lambda x: "/fake/input/tile_000000_ch_488.ims"
+
+        mock_stack2 = MagicMock()
+        mock_stack2.stem = "tile_000001_ch_561"
+        mock_stack2.name = "tile_000001_ch_561.ims"
+        mock_stack2.__str__ = lambda x: "/fake/input/tile_000001_ch_561.ims"
+
+        mock_acq_path = MagicMock()
+        mock_acq_path.exists.return_value = True
+
+        mock_input_path = MagicMock()
+        mock_input_path.joinpath.return_value = mock_acq_path
+
+        mock_output_path = MagicMock()
+
+        def path_side_effect(arg):
+            if arg == "/fake/input":
+                return mock_input_path
+            elif arg == "/fake/output":
+                return mock_output_path
+            return MagicMock()
+
+        mock_path_cls.side_effect = path_side_effect
+
+        # Different per-tile voxel resolutions, plus a (different)
+        # dataset-level value so we can assert per-tile wins.
+        def per_tile_lookup(_acq_path, tile_name):
+            return {
+                "tile_000000_ch_488.ims": [1.0, 0.5, 0.5],
+                "tile_000001_ch_561.ims": [2.0, 0.75, 0.75],
+            }[tile_name]
+
+        with patch.object(
+            ImarisCompressionJob,
+            "_get_tile_voxel_resolution_from_acquisition",
+            side_effect=per_tile_lookup,
+        ):
+            with patch.object(
+                ImarisCompressionJob,
+                "_get_voxel_resolution",
+                return_value=[9.0, 9.0, 9.0],
+            ):
+                with patch.object(
+                    ImarisCompressionJob,
+                    "_get_tile_translation_from_acquisition",
+                    return_value=None,
+                ):
+                    job._write_stacks([mock_stack1, mock_stack2])
+
+        self.assertEqual(mock_distributed_writer.call_count, 2)
+        call_kwargs = [c.kwargs for c in mock_distributed_writer.call_args_list]
+        # Map each call to its stack and check distinct voxel sizes
+        by_path = {kw["imaris_path"]: kw["voxel_size"] for kw in call_kwargs}
+        self.assertEqual(
+            by_path["/fake/input/tile_000000_ch_488.ims"], [1.0, 0.5, 0.5]
+        )
+        self.assertEqual(
+            by_path["/fake/input/tile_000001_ch_561.ims"], [2.0, 0.75, 0.75]
+        )
+
+    @patch(
+        "aind_exaspim_data_transformation.imaris_job.imaris_to_zarr_distributed"
+    )
+    @patch("aind_exaspim_data_transformation.imaris_job.Path")
+    def test_write_stacks_falls_back_to_dataset_resolution(
+        self, mock_path_cls, mock_distributed_writer
+    ):
+        """When per-tile lookup returns None, dataset-level value is used."""
+        settings = ImarisJobSettings(
+            input_source="/fake/input",
+            output_directory="/fake/output",
+            num_of_partitions=1,
+            partition_to_process=0,
+            use_tensorstore=True,
+            translate_imaris_pyramid=False,
+        )
+        job = ImarisCompressionJob(job_settings=settings)
+
+        mock_stack1 = MagicMock()
+        mock_stack1.stem = "stack1"
+        mock_stack1.name = "stack1.ims"
+        mock_stack1.__str__ = lambda x: "/fake/input/stack1.ims"
+
+        mock_acq_path = MagicMock()
+        mock_acq_path.exists.return_value = True
+
+        mock_input_path = MagicMock()
+        mock_input_path.joinpath.return_value = mock_acq_path
+
+        mock_output_path = MagicMock()
+
+        def path_side_effect(arg):
+            if arg == "/fake/input":
+                return mock_input_path
+            elif arg == "/fake/output":
+                return mock_output_path
+            return MagicMock()
+
+        mock_path_cls.side_effect = path_side_effect
+
+        with patch.object(
+            ImarisCompressionJob,
+            "_get_tile_voxel_resolution_from_acquisition",
+            return_value=None,
+        ):
+            with patch.object(
+                ImarisCompressionJob,
+                "_get_voxel_resolution",
+                return_value=[3.0, 0.25, 0.25],
+            ):
+                with patch.object(
+                    ImarisCompressionJob,
+                    "_get_tile_translation_from_acquisition",
+                    return_value=None,
+                ):
+                    job._write_stacks([mock_stack1])
+
+        mock_distributed_writer.assert_called_once()
+        self.assertEqual(
+            mock_distributed_writer.call_args.kwargs["voxel_size"],
+            [3.0, 0.25, 0.25],
+        )
+
     def test_get_compressor_blosc(self):
         """Test _get_compressor returns compressor kwargs for BLOSC"""
         job = ImarisCompressionJob(job_settings=self.test_settings)

--- a/tests/test_upgrade_metadata.py
+++ b/tests/test_upgrade_metadata.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from aind_exaspim_data_transformation.upgrade_metadata import (
+    _coerce_instrument_id,
     _derive_subject_id,
     _load_metadata_file,
     _needs_upgrade,
@@ -94,6 +95,45 @@ class TestWriteJsonToTempfile(unittest.TestCase):
 EXAMPLE_V1_ACQ = Path(__file__).resolve().parent.parent / (
     "docs/examples/acquisition.json"
 )
+
+
+class TestCoerceInstrumentId(unittest.TestCase):
+    """Tests for _coerce_instrument_id helper."""
+
+    def test_keeps_existing_value(self):
+        """A non-empty acquisition instrument_id is preserved as-is."""
+        acq = {"instrument_id": "exaSPIM-01", "data_streams": []}
+        inst = {"instrument_id": "other-id"}
+        out = _coerce_instrument_id(acq, inst)
+        self.assertEqual(out["instrument_id"], "exaSPIM-01")
+
+    def test_falls_back_to_instrument_when_empty(self):
+        """Empty acquisition instrument_id is replaced from instrument."""
+        acq = {"instrument_id": "", "data_streams": []}
+        inst = {"instrument_id": "exaSPIM-01"}
+        out = _coerce_instrument_id(acq, inst)
+        self.assertEqual(out["instrument_id"], "exaSPIM-01")
+
+    def test_falls_back_when_literal_none_string(self):
+        """The literal string 'None' is treated as missing."""
+        acq = {"instrument_id": "None", "data_streams": []}
+        inst = {"instrument_id": "exaSPIM-01"}
+        out = _coerce_instrument_id(acq, inst)
+        self.assertEqual(out["instrument_id"], "exaSPIM-01")
+
+    def test_returns_original_when_neither_set(self):
+        """If both sides are empty the value is left unchanged."""
+        acq = {"instrument_id": "", "data_streams": []}
+        inst: dict = {"instrument_id": ""}
+        out = _coerce_instrument_id(acq, inst)
+        self.assertEqual(out["instrument_id"], "")
+
+    def test_does_not_mutate_input(self):
+        """The original acquisition dict must not be modified in place."""
+        acq = {"instrument_id": "", "data_streams": []}
+        inst = {"instrument_id": "exaSPIM-01"}
+        _coerce_instrument_id(acq, inst)
+        self.assertEqual(acq["instrument_id"], "")
 
 
 class TestUpgradeMetadata(unittest.TestCase):


### PR DESCRIPTION
This pr fixes a newly discovered issue where tiles were not having their resolution written independently to zarr.json files. This led to incorrect voxel resolution and thus incorrect display of the data when viewed in neuroglancer, which appeared as 
<img width="1672" height="988" alt="{5233D959-6FD4-45CF-B3B1-687545ACD38F}" src="https://github.com/user-attachments/assets/9798ae37-ade2-4a2a-b44f-b49e0d2b02c9" />
